### PR TITLE
Fixes issue automation

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-documentation-update.yml
+++ b/.github/ISSUE_TEMPLATE/1-documentation-update.yml
@@ -19,12 +19,12 @@ body:
         - label: "General Docs Update - Not Application Specific"
 
   - type: checkboxes
-    id: update_type
+    id: type
     attributes:
       label: "Type of Update"
       description: "Select the type of documentation update."
       options:
-        - label: "New feature"
+        - label: "New Feature"
         - label: "Correction"
         - label: "Enhancement"
         - label: "Other"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,1 +1,0 @@
-blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/advanced-issue-labeler.yml
+++ b/.github/advanced-issue-labeler.yml
@@ -1,0 +1,30 @@
+policy:
+  - section:
+      - id: [application]
+        label:
+          - name: "Alloy"
+            keys: ["Alloy"]
+          - name: "Blueprint"
+            keys: ["Blueprint"]
+          - name: "Caster"
+            keys: ["Caster"]
+          - name: "CITE"
+            keys: ["CITE"]
+          - name: "Gallery"
+            keys: ["Gallery"]
+          - name: "Gameboard"
+            keys: ["Gameboard"]
+          - name: "Player"
+            keys: ["Player"]
+          - name: "Steamfitter"
+            keys: ["Steamfitter"]
+          - name: "TopoMojo"
+            keys: ["TopoMojo"]
+      - id: [type]
+        label:
+          - name: "New Feature"
+            keys: ["New Feature"]
+          - name: "Correction"
+            keys: ["Correction"]
+          - name: "Enhancement"
+            keys: ["Enhancement"]

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -2,85 +2,43 @@ name: Auto-label Documentation Update Issues
 
 on:
   issues:
-    types:
-      - opened
+    types: [ opened ]
+
+permissions:
+  contents: read
 
 jobs:
-  add-labels:
+  label-issue:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
     steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v3
 
-      - name: Extract issue body
-        id: extract_body
-        uses: actions/github-script@v7
+      - name: Parse issue form
+        uses: stefanbuck/github-issue-parser@v3
+        id: issue-parser
         with:
-          script: |
-            const issueBody = context.payload.issue.body;
-            return issueBody;
+          template-path: .github/ISSUE_TEMPLATE/1-documentation-update.yml
 
-      - name: Determine labels
-        id: determine_labels
-        run: |
-          LABELS=""
-
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Alloy"; then
-            LABELS="$LABELS Alloy"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Blueprint"; then
-            LABELS="$LABELS Blueprint"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Caster"; then
-            LABELS="$LABELS Caster"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] CITE"; then
-            LABELS="$LABELS CITE"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Gallery"; then
-            LABELS="$LABELS Gallery"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Gameboard"; then
-            LABELS="$LABELS Gameboard"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Player"; then
-            LABELS="$LABELS Player"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] Steamfitter"; then
-            LABELS="$LABELS Steamfitter"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] TopoMojo"; then
-            LABELS="$LABELS TopoMojo"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -Fq "- \[x\] General"; then
-            LABELS="$LABELS General"
-          fi
-
-
-
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -q "- \[x\] New feature"; then
-            LABELS="$LABELS New feature"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -q "- \[x\] Correction"; then
-            LABELS="$LABELS Correction"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -q "- \[x\] Enhancement"; then
-            LABELS="$LABELS Enhancement"
-          fi
-          if echo "${{ steps.extract_body.outputs.result }}" | grep -q "- \[x\] Other"; then
-            LABELS="$LABELS Other"
-          fi
-
-          echo "LABELS=$(echo $LABELS | xargs)" >> $GITHUB_ENV
-
-      - name: Add labels to issue
-        uses: actions/github-script@v7
+      - name: Set labels based on application field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
         with:
-          script: |
-            const labels = process.env.LABELS.split(' ');
-            github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: labels
-            });
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: application
+          block-list: |
+            None
+            General Docs Update - Not Application Specific
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set labels based on update_type field
+        uses: redhat-plumbers-in-action/advanced-issue-labeler@v3
+        with:
+          issue-form: ${{ steps.issue-parser.outputs.jsonString }}
+          section: update_type
+          block-list: |
+            None
+            Other
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1. When submitting an issue, you can use the configured form for documentation updates. The form has checkboxes for the app and type of update needed. It also has a free text field. 
2. When you submit the issue, a GitHub action runs that will automatically assign labels to the issue based on the boxes that you checked.  ("General Update" and "Other") checkbox are ignored - no labels associated with those. 