### PR TITLE
fixed some procedure wording for clarity

### DIFF
--- a/docs/caster/index.md
+++ b/docs/caster/index.md
@@ -14,7 +14,7 @@ Caster should give experts the control they need, while also making it easy for 
 
 For more information on native Terraform constructs used in Caster, please refer to the [Terraform documentation](https://www.terraform.io/docs/index.html).
 
-## Administrator User Guide
+## Administrator Guide
 
 ### Users
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -244,8 +244,8 @@ To edit an evaluation, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Evaluations** tab.
-3. Select the evaluation to be edited and click the **Edit Icon** next to the evaluation.
-4. Here, users will be prompted the same evaluation's edit component as when adding a new evaluation.
+3. Select the evaluation you wish to edit and click the **Edit Icon** next to the evaluation.
+4. The system opens the same edit component used when creating a new evaluation.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete an Evaluation
@@ -314,8 +314,8 @@ To edit a move, follow these steps:
 1. Click the **Settings Cog**.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to be edited and click the **Moves** tab.
-4. Select the move to be edited, and click the **Edit Icon** next to the move.
-5. Here, users will be prompted the same move's edit component as when adding a new move.
+4. Select the move you wish to edit and click the **Edit Icon** next to the move.
+5. The system opens the same edit component used when creating a new move.
 6. After doing all the necessary edits, click **Save**.
 
 #### Delete a Move
@@ -352,8 +352,8 @@ To edit a team, follow these steps:
 1. Click the **Settings Cog**.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to be edited and click the **Teams** tab.
-4. Select the team to be edited, and click the **Edit Icon** next to the team.
-5. Here, users will be prompted the same team's edit component as when adding a new team.
+4. Select the team you wish to edit and click the **Edit Icon** next to the team.
+5. The system opens the same edit component used when creating a new team.
 6. After doing all the necessary edits, click **Save**.
 
 #### Delete a Team
@@ -431,8 +431,8 @@ To edit a scoring model, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Scoring Models** tab.
-3. Select the scoring model to be edited, and click the **Edit Icon** next to the scoring model.
-4. Here, users will be prompted the same scoring model's edit component as when adding a new scoring model.
+3. Select the scoring model you wish to edit and click the **Edit Icon** next to the scoring model.
+4. The system opens the same edit component used when creating a new scoring model.
 5. After doing all the necessary edits, click **Save**.
 
 #### Upload a Scoring Model
@@ -519,8 +519,8 @@ To edit a scoring category, follow these steps:
 1. Click the **Settings Cog**.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to be edited, and click the **Scoring Categories** tab.
-4. Select the scoring category to be edited, and click the **Edit Icon** next to the scoring category.
-5. Here, users will be prompted the same scoring category's edit component as when adding a new scoring category.
+4. Select the scoring category you wish to edit and click the **Edit Icon** next to the scoring category.
+5. The system opens the same edit component used when creating a new scoring category.
 6. After doing all the necessary edits, click **Save**.
 
 #### Delete a Scoring Category
@@ -562,8 +562,8 @@ To edit a scoring option, follow these steps:
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to be edited, and click the **Scoring Categories** tab.
 4. Select the scoring category to be edited, and click the **Scoring Options** tab.
-5. Select the scoring option to be edited, and click the **Edit Icon** next to the scoring option.
-6. Here, users will be prompted the same scoring option's edit component as when adding a new scoring option.
+5. Select the scoring option you wish to edit and click the **Edit Icon** next to the scoring option.
+6. The system opens the same edit component used when creating a new scoring option.
 7. After doing all the necessary edits, click **Save**.
 
 #### Delete a Scoring Option
@@ -609,8 +609,8 @@ To edit an action, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Actions** tab.
-3. Select the action to be edited, and click the **Edit Icon** next to the action.
-4. Here, users will be prompted the same action's edit component as when adding a new action.
+3. Select the action you wish to edit and click the **Edit Icon** next to the action.
+4. The system opens the same edit component used when creating a new action.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete an Action
@@ -653,8 +653,8 @@ To edit a role, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Roles** tab.
-3. Select the role to be edited, and click the **Edit Icon** next to the role.
-4. Here, users will be prompted the same role's edit component as when adding a new role.
+3. Select the role you wish to edit and click the **Edit Icon** next to the role.
+4. The system opens the same edit component used when creating a new role.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete a Role
@@ -704,8 +704,8 @@ To edit a team type, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Team Types** tab.
-3. Select the team type to be edited, and click the **Edit Icon** next to the team type.
-4. Here, users will be prompted the same team type's edit component as when adding a new team type.
+3. Select the team type you wish to edit and click the **Edit Icon** next to the team type.
+4. The system opens the same edit component used when creating a new team type.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete a Team Type

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -211,8 +211,8 @@ After creating your article, it will be displayed in the Gallery Archive in the 
 
 To edit an article, follow these steps:
 
-1. On the Gallery Archive section, select the article to be edited and click the **Edit Icon** on the article's card.
-2. Here, users will be prompted the same article's edit component as when adding a new article.
+1. On the Gallery Archive section, select the article you wish to edit and click the **Edit Icon** on the article's card.
+2. The system opens the same edit component used when creating a new article.
 3. After doing all the necessary edits, click **Save**.
 
 #### Delete an Article
@@ -261,8 +261,8 @@ To edit a user, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Users** tab.
-3. Select the user to be edited and click the **Edit Icon** next to the user.
-4. Here, users will be prompted the same user's edit component as when adding a new user.
+3. Select the user you wish to edit and click the **Edit Icon** next to the user.
+4. The system opens the same edit component used when creating a new user.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete a User
@@ -303,8 +303,8 @@ To edit a collection, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Collections** tab.
-3. Select the collection to be edited and click the **Edit Icon** next to the collection.
-4. Here, users will be prompted the same collection's edit component as when adding a new collection.
+3. Select the collection you wish to edit and click the **Edit Icon** next to the collection.
+4. The system opens the same edit component used when creating a new collection.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete a Collection
@@ -373,8 +373,8 @@ To edit a card, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Cards** tab.
-3. Select the card to be edited and click the **Edit Icon** next to the card.
-4. Here, users will be prompted the same card's edit component as when adding a new card.
+3. Select the card you wish to edit and click the **Edit Icon** next to the card.
+4. The system opens the same edit component used when creating a new card.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete a Card
@@ -425,8 +425,8 @@ To edit an article, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Articles** tab.
-3. Select the article to be edited and click the **Edit Icon** next to the article.
-4. Here, users will be prompted the same article's edit component as when adding a new article.
+3. Select the article you wish to edit and click the **Edit Icon** next to the article.
+4. The system opens the same edit component used when creating a new article.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete an Article
@@ -468,8 +468,8 @@ To edit an exhibit, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Exhibits** tab.
-3. Select the exhibit to be edited and click the **Edit Icon** next to the exhibit.
-4. Here, users will be prompted the same exhibit's edit component as when adding a new exhibit.
+3. Select the exhibit you wish to edit and click the **Edit Icon** next to the exhibit.
+4. The system opens the same edit component used when creating a new exhibit.
 5. After doing all the necessary edits, click **Save**.
 
 #### Delete an Exhibit

--- a/docs/player/index.md
+++ b/docs/player/index.md
@@ -18,7 +18,7 @@ Player is ***not*** meant to:
 - Provide any mechanisms for individual applications to communicate with each other.
 - Provide any default applications. However, an exercise can consume some common applications.
 
-## Administrator User Guide
+## Administrator Guide
 
 ![admin button](../assets/img/admin button.png)
 


### PR DESCRIPTION
I changed some wording in "edit" procedures to make the steps a little more clear.

I renamed the Caster and Player heading to “Administrator Guide” from “Administrator _User_ Guide”. 