### PR TITLE
Reordered topics in the User Guide/Admin Guide for Blueprint, CITE, and Gallery

### DIFF
--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -23,11 +23,13 @@ There are three levels of permissions in Blueprint that affect the way a user in
 
 Most users will have the Content Developer permission, because it is the minimum required permission to create and collaborate with other teams on MSEL creation.
 
-Refer to this section [Administrator Guide](#administrator-guide) for more information on additional administrative actions.
+Refer to the [Administrator Guide](#administrator-guide) for more information on additional administrative actions.
 
 ## Administrator Guide
 
-## Administration View
+Blueprint administrators use the Administration View to manage users and units, and to configure organization, Gallery card, CITE action, and CITE role templates for content developers building MSELs.
+
+### Administration View
 
 Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. The Administration View is where admins prepare and manage the environment so events run smoothly for participants.
 
@@ -36,13 +38,13 @@ Accessing the Administration View is the same in all Crucible exercise applicati
 ![The Administration dropdown in the top right-corner](img/crucible-administration.png)
 
 
-### Units
+#### Units
 
 The following image shows the Units Administration Page. Here, administrators can add, edit, and delete units. To use the Blueprint application, the administrator should assign a unit to desired users.
 
 ![Blueprint Teams Admin OE](img/blueprintUnits-v2.png)
 
-#### Add a Unit
+##### Add a Unit
 
 If the exercise administrator has granted the appropriate permissions, follow these steps to add a unit.
 
@@ -52,7 +54,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 2. Under the Units Administration View, click **+**.
 3. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field          | Data Type | Description             | Example                    |
 | -------------- | --------- | ----------------------- | -------------------------- |
@@ -61,7 +63,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 After you've added all desired configurations, click **Save**.
 
-#### Edit a Unit
+##### Edit a Unit
 
 To edit a unit, follow these steps:
 
@@ -70,21 +72,21 @@ To edit a unit, follow these steps:
 3. The system opens the same edit component used when creating a new unit.
 4. Make your changes, then click **Save**.
 
-#### Delete a Unit
+##### Delete a Unit
 
 To delete a unit, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Units Administration View, select the unit you want to delete and click the **Trash Can** next to it.
 
-#### Search for a Unit
+##### Search for a Unit
 
 To search for a specific unit, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Units Administration View, click the **Search Bar** and type the name of the desired unit.
 
-#### Add/Remove Users from a Unit
+##### Add/Remove Users from a Unit
 
 To configure a unit for an exercise, administrators add users to their respective units. To do this, follow these steps.
 
@@ -94,7 +96,7 @@ To configure a unit for an exercise, administrators add users to their respectiv
 2. The **All Users** tab shows *unassigned* users. To add a user to the unit, click **Add User**.
 3. The **Unit Users** tab shows *assigned* users. To remove a user from the unit, click **Remove**.
 
-### Users
+#### Users
 
 The following image shows the Users Administration Page. Here, administrators can add and delete users. Additionally, administrators can assign the necessary permissions to each user.
 
@@ -105,7 +107,7 @@ The available permissions are:
 
 ![Blueprint Users Admin OE](img/blueprintUsersAdmin-v4.png)
 
-#### Add a User
+##### Add a User
 
 If the exercise administrator has granted the appropriate permissions, follow these steps to add a user.
 
@@ -114,7 +116,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 1. Under the Users Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field         | Data Type | Description            | Example                              |
 | ------------- | --------- | ---------------------- | ------------------------------------ |
@@ -123,27 +125,27 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 Click the **Save** icon (a user with a **+** sign), then select the permissions you want to assign by checking the boxes next to the user's name.
 
-#### Delete a User
+##### Delete a User
 
 To delete a user, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Users Administration View, select the user you want to delete and click the **Trash Can** next to the user.
 
-#### Search for a User
+##### Search for a User
 
 To search for a specific user, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Users Administration View, click the **Search Bar** and type the name of the desired user.
 
-### Organization Templates
+#### Organization Templates
 
 The following image shows the Organization Templates Administration Page. Here, administrators can add and delete organization templates.
 
 ![Blueprint Organizations Admin OE](img/blueprintOrganizationsAdmin-v2.png)
 
-#### Add an Organization Template
+##### Add an Organization Template
 
 If the exercise administrator has granted the appropriate permissions, follow these steps to add an organization template.
 
@@ -152,7 +154,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 1. Under the Organizations Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field           | Data Type | Description                                                   | Example                                                                                                                                                                                                  |
 | --------------- | --------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -164,7 +166,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 After you've added all desired configurations, click **Save**.
 
-#### Edit an Organization Template
+##### Edit an Organization Template
 
 To edit an organization template, follow these steps:
 
@@ -173,27 +175,27 @@ To edit an organization template, follow these steps:
 3. The system opens the same edit form used when creating a new organization template.
 4. Make your changes, then click **Save**.
 
-#### Delete an Organization Template
+##### Delete an Organization Template
 
 To delete an organization template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Organizations Administration View, select the organization you want to delete and click the **Trash Can** next to the organization template.
 
-#### Search For an Organization Template
+##### Search For an Organization Template
 
 To search for a specific organization template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Organizations Administration View, click the **Search Bar** and type the name of the desired organization template.
 
-### Gallery Card Templates
+#### Gallery Card Templates
 
 The following image shows the Gallery Card Templates Administration Page. Here, administrators can add and delete Gallery card templates.
 
 ![Blueprint Cards Admin OE](img/blueprintCardsAdmin-v2.png)
 
-#### Add a Gallery Card Template
+##### Add a Gallery Card Template
 
 If the exercise administrator has granted the appropriate permissions, follow these steps to add a Gallery card template.
 
@@ -202,7 +204,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 1. Under the Gallery Cards Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                | Data Type | Description                                                   | Example                                     |
 | -------------------- | --------- | ------------------------------------------------------------- | ------------------------------------------- |
@@ -211,7 +213,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 After you've added all desired configurations, click **Save**.
 
-#### Edit a Gallery Card Template
+##### Edit a Gallery Card Template
 
 To edit a Gallery card template, follow these steps:
 
@@ -220,27 +222,27 @@ To edit a Gallery card template, follow these steps:
 3. The system opens the same edit component used when creating a new card template.
 4. Make your changes, then click **Save**.
 
-#### Delete a Gallery Card Template
+##### Delete a Gallery Card Template
 
 To delete an Gallery card template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Gallery Cards Administration View, select the card template you want to delete and click the **Trash Can** next to it.
 
-#### Search for a Gallery Card Template
+##### Search for a Gallery Card Template
 
 To search for a specific Gallery card template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the Gallery Cards Administration View, click the **Search Bar** and type the name of the desired card template.
 
-### CITE Actions Templates
+#### CITE Actions Templates
 
 The following image shows the CITE Action Templates administration page. Here, administrators can add and delete CITE action templates.
 
 ![Blueprint Actions Admin OE](img/blueprintActionsAdmin-v2.png)
 
-#### Add a CITE Action Template
+##### Add a CITE Action Template
 
 If the exercise administrator has granted the appropriate permissions, follow these steps to add a CITE action template.
 
@@ -249,7 +251,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 1. Under the CITE Actions Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                         | Data Type | Description                                                  | Example            |
 | ----------------------------- | --------- | ------------------------------------------------------------ | ------------------ |
@@ -257,7 +259,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 After you've added all desired configurations, click **Save**.
 
-#### Edit a CITE Action Template
+##### Edit a CITE Action Template
 
 To edit a CITE action template, follow these steps:
 
@@ -266,27 +268,27 @@ To edit a CITE action template, follow these steps:
 3. The system opens the same edit component used when creating a new action template.
 4. Make your changes, then click **Save**.
 
-#### Delete a CITE Action Template
+##### Delete a CITE Action Template
 
-To delete an CITE action template, follow these steps:
+To delete a CITE action template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the CITE Actions Administration View, select the action template you want to delete and click the **Trash Can** next to it.
 
-#### Search for a CITE Action Template
+##### Search for a CITE Action Template
 
 To search for a specific CITE action template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the CITE Actions Administration View, click the **Search Bar** and type the name of the desired action template.
 
-### CITE Roles Templates
+#### CITE Roles Templates
 
 The following image shows the CITE Roles Templates Administration Page. Here, administrators can add and delete CITE roles templates.
 
 ![Blueprint Roles Admin OE](img/blueprintRolesAdmin-v2.png)
 
-#### Add a CITE Role Template
+##### Add a CITE Role Template
 
 If the exercise administrator has granted the appropriate permissions, follow these steps to add a CITE role template.
 
@@ -295,7 +297,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 1. Under the CITE Roles Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field    | Data Type | Description      | Example  |
 | -------- | --------- | ---------------- | -------- |
@@ -303,7 +305,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 After you've added all desired configurations, click **Save**.
 
-#### Edit a CITE Role Template
+##### Edit a CITE Role Template
 
 To edit a CITE role template, follow these steps:
 
@@ -312,14 +314,14 @@ To edit a CITE role template, follow these steps:
 3. The system opens the same edit component used when creating a new role template.
 4. Make your changes, then click **Save**.
 
-#### Delete a CITE Role Template
+##### Delete a CITE Role Template
 
 To delete a CITE role template, follow these steps:
 
 1. Click the **Settings Cog** in the top-right corner of the screen.
 2. Under the CITE Roles Administration View, select the role template you want to delete and click the **Trash Can** next to it.
 
-#### Search For a CITE Role Template
+##### Search For a CITE Role Template
 
 To search for a specific CITE role template, follow these steps:
 
@@ -590,7 +592,7 @@ The available roles are:
 - **[`Observer`](#glossary):** When the MSEL owner has enabled Gallery or CITE integrations, this role allows a user to observe other team's progress on CITE and Gallery applications.
 - **[`Incrementer`](#glossary):** When the MSEL owner has enabled CITE integration, this role allows a user to advance the current move.
 - **[`Modifier`](#glossary):** When the MSEL owner has enabled CITE integration, this role allows a user to modify the team's score.
-- **[`Submitter`](#glossary):**When the MSEL owner has enabled integration, this role allows a user to submit the team's score.
+- **[`Submitter`](#glossary):** When the MSEL owner has enabled integration, this role allows a user to submit the team's score.
 
 #### Data Fields
 

--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -25,6 +25,307 @@ Most users will have the Content Developer permission, because it is the minimum
 
 Refer to this section [Administrator Guide](#administrator-guide) for more information on additional administrative actions.
 
+## Administrator Guide
+
+## Administration View
+
+Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. The Administration View is where admins prepare and manage the environment so events run smoothly for participants.
+
+Accessing the Administration View is the same in all Crucible exercise applications: expand the dropdown next to your username in the top-right corner and select **Administration**.
+
+![The Administration dropdown in the top right-corner](img/crucible-administration.png)
+
+
+### Units
+
+The following image shows the Units Administration Page. Here, administrators can add, edit, and delete units. To use the Blueprint application, the administrator should assign a unit to desired users.
+
+![Blueprint Teams Admin OE](img/blueprintUnits-v2.png)
+
+#### Add a Unit
+
+If the exercise administrator has granted the appropriate permissions, follow these steps to add a unit.
+
+![Blueprint Add Team OE](img/blueprintAddUnit.png)
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Units Administration View, click **+**.
+3. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field          | Data Type | Description             | Example                    |
+| -------------- | --------- | ----------------------- | -------------------------- |
+| **Name**       | String    | Name for the unit       | Carnegie Mellon University |
+| **Short Name** | String    | Short name for the unit | CMU                        |
+
+After you've added all desired configurations, click **Save**.
+
+#### Edit a Unit
+
+To edit a unit, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under Units Administration View, select the unit you want to edit and click **Edit** next to it.
+3. The system opens the same edit component used when creating a new unit.
+4. Make your changes, then click **Save**.
+
+#### Delete a Unit
+
+To delete a unit, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Units Administration View, select the unit you want to delete and click the **Trash Can** next to it.
+
+#### Search for a Unit
+
+To search for a specific unit, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Units Administration View, click the **Search Bar** and type the name of the desired unit.
+
+#### Add/Remove Users from a Unit
+
+To configure a unit for an exercise, administrators add users to their respective units. To do this, follow these steps.
+
+![Configure Blueprint Teams OE](img/blueprintConfigureUnits-v2.png)
+
+1. Select the unit you want to configure and click to expand its configuration details.
+2. The **All Users** tab shows *unassigned* users. To add a user to the unit, click **Add User**.
+3. The **Unit Users** tab shows *assigned* users. To remove a user from the unit, click **Remove**.
+
+### Users
+
+The following image shows the Users Administration Page. Here, administrators can add and delete users. Additionally, administrators can assign the necessary permissions to each user.
+
+The available permissions are:
+
+- **System Admin:** Can use all administration privileges on the Blueprint application.
+- **Content Developer:** Can view, edit, create, and approve events on the MSEL.
+
+![Blueprint Users Admin OE](img/blueprintUsersAdmin-v4.png)
+
+#### Add a User
+
+If the exercise administrator has granted the appropriate permissions, follow these steps to add a user.
+
+![Blueprint Add User OE](img/blueprintAddUser-v3.png)
+
+1. Under the Users Administration View, click **+**.
+2. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field         | Data Type | Description            | Example                              |
+| ------------- | --------- | ---------------------- | ------------------------------------ |
+| **User ID**   | GUID      | Unique ID for the user | 9dd4e3d8-5098-4b0a-9216-697cda5553f8 |
+| **User Name** | String    | User name identifier   | user-2                               |
+
+Click the **Save** icon (a user with a **+** sign), then select the permissions you want to assign by checking the boxes next to the user's name.
+
+#### Delete a User
+
+To delete a user, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Users Administration View, select the user you want to delete and click the **Trash Can** next to the user.
+
+#### Search for a User
+
+To search for a specific user, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Users Administration View, click the **Search Bar** and type the name of the desired user.
+
+### Organization Templates
+
+The following image shows the Organization Templates Administration Page. Here, administrators can add and delete organization templates.
+
+![Blueprint Organizations Admin OE](img/blueprintOrganizationsAdmin-v2.png)
+
+#### Add an Organization Template
+
+If the exercise administrator has granted the appropriate permissions, follow these steps to add an organization template.
+
+![Blueprint Add Organization Template OE](img/blueprintAddOrgTemplate.png)
+
+1. Under the Organizations Administration View, click **+**.
+2. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field           | Data Type | Description                                                   | Example                                                                                                                                                                                                  |
+| --------------- | --------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Long Name**   | String    | Add the complete name for the organization                    | Cybersecurity and Infrastructure Security Agency                                                                                                                                                         |
+| **Short Name**  | String    | Add a short name for the organization, such as an acronym     | `CISA`                                                                                                                                                                                                   |
+| **Summary**     | String    | Organization's short summary                                  | Security agency                                                                                                                                                                                          |
+| **Email**       | String    | Organization's email contact                                  | `john@cisa.gov`                                                                                                                                                                                          |
+| **Description** | Rich Text | Information, details, and characteristics of the organization | The Cybersecurity and Infrastructure Security Agency (CISA) is an agency of the Department of Homeland Security (DHS) that is responsible for strengthening cybersecurity and infrastructure protection. |
+
+After you've added all desired configurations, click **Save**.
+
+#### Edit an Organization Template
+
+To edit an organization template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under Organizations Administration View, select the organization you want to edit and click **Edit** next to the organization template.
+3. The system opens the same edit form used when creating a new organization template.
+4. Make your changes, then click **Save**.
+
+#### Delete an Organization Template
+
+To delete an organization template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Organizations Administration View, select the organization you want to delete and click the **Trash Can** next to the organization template.
+
+#### Search For an Organization Template
+
+To search for a specific organization template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Organizations Administration View, click the **Search Bar** and type the name of the desired organization template.
+
+### Gallery Card Templates
+
+The following image shows the Gallery Card Templates Administration Page. Here, administrators can add and delete Gallery card templates.
+
+![Blueprint Cards Admin OE](img/blueprintCardsAdmin-v2.png)
+
+#### Add a Gallery Card Template
+
+If the exercise administrator has granted the appropriate permissions, follow these steps to add a Gallery card template.
+
+![Blueprint Add Card Template OE](img/blueprintAddCardTemplate.png)
+
+1. Under the Gallery Cards Administration View, click **+**.
+2. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field                | Data Type | Description                                                   | Example                                     |
+| -------------------- | --------- | ------------------------------------------------------------- | ------------------------------------------- |
+| **Name**             | String    | Gallery card name                                             | Information Technology Sector               |
+| **Card Description** | String    | Information, details, and characteristics of the Gallery card | Status of the Information Technology Sector |
+
+After you've added all desired configurations, click **Save**.
+
+#### Edit a Gallery Card Template
+
+To edit a Gallery card template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under Gallery Cards Administration View, select the card template you want to edit and click **Edit** next to it.
+3. The system opens the same edit component used when creating a new card template.
+4. Make your changes, then click **Save**.
+
+#### Delete a Gallery Card Template
+
+To delete an Gallery card template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Gallery Cards Administration View, select the card template you want to delete and click the **Trash Can** next to it.
+
+#### Search for a Gallery Card Template
+
+To search for a specific Gallery card template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the Gallery Cards Administration View, click the **Search Bar** and type the name of the desired card template.
+
+### CITE Actions Templates
+
+The following image shows the CITE Action Templates administration page. Here, administrators can add and delete CITE action templates.
+
+![Blueprint Actions Admin OE](img/blueprintActionsAdmin-v2.png)
+
+#### Add a CITE Action Template
+
+If the exercise administrator has granted the appropriate permissions, follow these steps to add a CITE action template.
+
+![Blueprint CITE Action Template OE](img/AddCITEActionTemplate.png)
+
+1. Under the CITE Actions Administration View, click **+**.
+2. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field                         | Data Type | Description                                                  | Example            |
+| ----------------------------- | --------- | ------------------------------------------------------------ | ------------------ |
+| **Description of the Action** | String    | Information, details, and characteristics of the CITE action | Score the incident |
+
+After you've added all desired configurations, click **Save**.
+
+#### Edit a CITE Action Template
+
+To edit a CITE action template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under CITE Actions Administration View, select the action template you want to edit and click **Edit** next to it.
+3. The system opens the same edit component used when creating a new action template.
+4. Make your changes, then click **Save**.
+
+#### Delete a CITE Action Template
+
+To delete an CITE action template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the CITE Actions Administration View, select the action template you want to delete and click the **Trash Can** next to it.
+
+#### Search for a CITE Action Template
+
+To search for a specific CITE action template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the CITE Actions Administration View, click the **Search Bar** and type the name of the desired action template.
+
+### CITE Roles Templates
+
+The following image shows the CITE Roles Templates Administration Page. Here, administrators can add and delete CITE roles templates.
+
+![Blueprint Roles Admin OE](img/blueprintRolesAdmin-v2.png)
+
+#### Add a CITE Role Template
+
+If the exercise administrator has granted the appropriate permissions, follow these steps to add a CITE role template.
+
+![Blueprint CITE Role Template OE](img/AddCITERoleTemplate.png)
+
+1. Under the CITE Roles Administration View, click **+**.
+2. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field    | Data Type | Description      | Example  |
+| -------- | --------- | ---------------- | -------- |
+| **Name** | String    | Name of the role | Reviewer |
+
+After you've added all desired configurations, click **Save**.
+
+#### Edit a CITE Role Template
+
+To edit a CITE role template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under CITE Roles Administration View, select the role template you want to edit and click **Edit** next to it.
+3. The system opens the same edit component used when creating a new role template.
+4. Make your changes, then click **Save**.
+
+#### Delete a CITE Role Template
+
+To delete a CITE role template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the CITE Roles Administration View, select the role template you want to delete and click the **Trash Can** next to it.
+
+#### Search For a CITE Role Template
+
+To search for a specific CITE role template, follow these steps:
+
+1. Click the **Settings Cog** in the top-right corner of the screen.
+2. Under the CITE Roles Administration View, click the **Search Bar** and type the name of the desired role template.
+
 ## User Guide
 
 ### Blueprint Landing Page
@@ -942,307 +1243,6 @@ To remove MSEL information from the applications, follow these steps:
 
 1. Navigate to the **Info** tab.
 2. Click **Remove Integrations**.
-
-## Administrator Guide
-
-## Administration View
-
-Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. The Administration View is where admins prepare and manage the environment so events run smoothly for participants.
-
-Accessing the Administration View is the same in all Crucible exercise applications: expand the dropdown next to your username in the top-right corner and select **Administration**.
-
-![The Administration dropdown in the top right-corner](img/crucible-administration.png)
-
-
-### Units
-
-The following image shows the Units Administration Page. Here, administrators can add, edit, and delete units. To use the Blueprint application, the administrator should assign a unit to desired users.
-
-![Blueprint Teams Admin OE](img/blueprintUnits-v2.png)
-
-#### Add a Unit
-
-If the exercise administrator has granted the appropriate permissions, follow these steps to add a unit.
-
-![Blueprint Add Team OE](img/blueprintAddUnit.png)
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Units Administration View, click **+**.
-3. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field          | Data Type | Description             | Example                    |
-| -------------- | --------- | ----------------------- | -------------------------- |
-| **Name**       | String    | Name for the unit       | Carnegie Mellon University |
-| **Short Name** | String    | Short name for the unit | CMU                        |
-
-After you've added all desired configurations, click **Save**.
-
-#### Edit a Unit
-
-To edit a unit, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under Units Administration View, select the unit you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new unit.
-4. Make your changes, then click **Save**.
-
-#### Delete a Unit
-
-To delete a unit, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Units Administration View, select the unit you want to delete and click the **Trash Can** next to it.
-
-#### Search for a Unit
-
-To search for a specific unit, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Units Administration View, click the **Search Bar** and type the name of the desired unit.
-
-#### Add/Remove Users from a Unit
-
-To configure a unit for an exercise, administrators add users to their respective units. To do this, follow these steps.
-
-![Configure Blueprint Teams OE](img/blueprintConfigureUnits-v2.png)
-
-1. Select the unit you want to configure and click to expand its configuration details.
-2. The **All Users** tab shows *unassigned* users. To add a user to the unit, click **Add User**.
-3. The **Unit Users** tab shows *assigned* users. To remove a user from the unit, click **Remove**.
-
-### Users
-
-The following image shows the Users Administration Page. Here, administrators can add and delete users. Additionally, administrators can assign the necessary permissions to each user.
-
-The available permissions are:
-
-- **System Admin:** Can use all administration privileges on the Blueprint application.
-- **Content Developer:** Can view, edit, create, and approve events on the MSEL.
-
-![Blueprint Users Admin OE](img/blueprintUsersAdmin-v4.png)
-
-#### Add a User
-
-If the exercise administrator has granted the appropriate permissions, follow these steps to add a user.
-
-![Blueprint Add User OE](img/blueprintAddUser-v3.png)
-
-1. Under the Users Administration View, click **+**.
-2. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field         | Data Type | Description            | Example                              |
-| ------------- | --------- | ---------------------- | ------------------------------------ |
-| **User ID**   | GUID      | Unique ID for the user | 9dd4e3d8-5098-4b0a-9216-697cda5553f8 |
-| **User Name** | String    | User name identifier   | user-2                               |
-
-Click the **Save** icon (a user with a **+** sign), then select the permissions you want to assign by checking the boxes next to the user's name.
-
-#### Delete a User
-
-To delete a user, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Users Administration View, select the user you want to delete and click the **Trash Can** next to the user.
-
-#### Search for a User
-
-To search for a specific user, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Users Administration View, click the **Search Bar** and type the name of the desired user.
-
-### Organization Templates
-
-The following image shows the Organization Templates Administration Page. Here, administrators can add and delete organization templates.
-
-![Blueprint Organizations Admin OE](img/blueprintOrganizationsAdmin-v2.png)
-
-#### Add an Organization Template
-
-If the exercise administrator has granted the appropriate permissions, follow these steps to add an organization template.
-
-![Blueprint Add Organization Template OE](img/blueprintAddOrgTemplate.png)
-
-1. Under the Organizations Administration View, click **+**.
-2. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field           | Data Type | Description                                                   | Example                                                                                                                                                                                                  |
-| --------------- | --------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Long Name**   | String    | Add the complete name for the organization                    | Cybersecurity and Infrastructure Security Agency                                                                                                                                                         |
-| **Short Name**  | String    | Add a short name for the organization, such as an acronym     | `CISA`                                                                                                                                                                                                   |
-| **Summary**     | String    | Organization's short summary                                  | Security agency                                                                                                                                                                                          |
-| **Email**       | String    | Organization's email contact                                  | `john@cisa.gov`                                                                                                                                                                                          |
-| **Description** | Rich Text | Information, details, and characteristics of the organization | The Cybersecurity and Infrastructure Security Agency (CISA) is an agency of the Department of Homeland Security (DHS) that is responsible for strengthening cybersecurity and infrastructure protection. |
-
-After you've added all desired configurations, click **Save**.
-
-#### Edit an Organization Template
-
-To edit an organization template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under Organizations Administration View, select the organization you want to edit and click **Edit** next to the organization template.
-3. The system opens the same edit form used when creating a new organization template.
-4. Make your changes, then click **Save**.
-
-#### Delete an Organization Template
-
-To delete an organization template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Organizations Administration View, select the organization you want to delete and click the **Trash Can** next to the organization template.
-
-#### Search For an Organization Template
-
-To search for a specific organization template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Organizations Administration View, click the **Search Bar** and type the name of the desired organization template.
-
-### Gallery Card Templates
-
-The following image shows the Gallery Card Templates Administration Page. Here, administrators can add and delete Gallery card templates.
-
-![Blueprint Cards Admin OE](img/blueprintCardsAdmin-v2.png)
-
-#### Add a Gallery Card Template
-
-If the exercise administrator has granted the appropriate permissions, follow these steps to add a Gallery card template.
-
-![Blueprint Add Card Template OE](img/blueprintAddCardTemplate.png)
-
-1. Under the Gallery Cards Administration View, click **+**.
-2. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field                | Data Type | Description                                                   | Example                                     |
-| -------------------- | --------- | ------------------------------------------------------------- | ------------------------------------------- |
-| **Name**             | String    | Gallery card name                                             | Information Technology Sector               |
-| **Card Description** | String    | Information, details, and characteristics of the Gallery card | Status of the Information Technology Sector |
-
-After you've added all desired configurations, click **Save**.
-
-#### Edit a Gallery Card Template
-
-To edit a Gallery card template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under Gallery Cards Administration View, select the card template you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new card template.
-4. Make your changes, then click **Save**.
-
-#### Delete a Gallery Card Template
-
-To delete an Gallery card template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Gallery Cards Administration View, select the card template you want to delete and click the **Trash Can** next to it.
-
-#### Search for a Gallery Card Template
-
-To search for a specific Gallery card template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the Gallery Cards Administration View, click the **Search Bar** and type the name of the desired card template.
-
-### CITE Actions Templates
-
-The following image shows the CITE Action Templates administration page. Here, administrators can add and delete CITE action templates.
-
-![Blueprint Actions Admin OE](img/blueprintActionsAdmin-v2.png)
-
-#### Add a CITE Action Template
-
-If the exercise administrator has granted the appropriate permissions, follow these steps to add a CITE action template.
-
-![Blueprint CITE Action Template OE](img/AddCITEActionTemplate.png)
-
-1. Under the CITE Actions Administration View, click **+**.
-2. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field                         | Data Type | Description                                                  | Example            |
-| ----------------------------- | --------- | ------------------------------------------------------------ | ------------------ |
-| **Description of the Action** | String    | Information, details, and characteristics of the CITE action | Score the incident |
-
-After you've added all desired configurations, click **Save**.
-
-#### Edit a CITE Action Template
-
-To edit a CITE action template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under CITE Actions Administration View, select the action template you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new action template.
-4. Make your changes, then click **Save**.
-
-#### Delete a CITE Action Template
-
-To delete an CITE action template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the CITE Actions Administration View, select the action template you want to delete and click the **Trash Can** next to it.
-
-#### Search for a CITE Action Template
-
-To search for a specific CITE action template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the CITE Actions Administration View, click the **Search Bar** and type the name of the desired action template.
-
-### CITE Roles Templates
-
-The following image shows the CITE Roles Templates Administration Page. Here, administrators can add and delete CITE roles templates.
-
-![Blueprint Roles Admin OE](img/blueprintRolesAdmin-v2.png)
-
-#### Add a CITE Role Template
-
-If the exercise administrator has granted the appropriate permissions, follow these steps to add a CITE role template.
-
-![Blueprint CITE Role Template OE](img/AddCITERoleTemplate.png)
-
-1. Under the CITE Roles Administration View, click **+**.
-2. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field    | Data Type | Description      | Example  |
-| -------- | --------- | ---------------- | -------- |
-| **Name** | String    | Name of the role | Reviewer |
-
-After you've added all desired configurations, click **Save**.
-
-#### Edit a CITE Role Template
-
-To edit a CITE role template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under CITE Roles Administration View, select the role template you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new role template.
-4. Make your changes, then click **Save**.
-
-#### Delete a CITE Role Template
-
-To delete a CITE role template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the CITE Roles Administration View, select the role template you want to delete and click the **Trash Can** next to it.
-
-#### Search For a CITE Role Template
-
-To search for a specific CITE role template, follow these steps:
-
-1. Click the **Settings Cog** in the top-right corner of the screen.
-2. Under the CITE Roles Administration View, click the **Search Bar** and type the name of the desired role template.
 
 ## Glossary
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -30,183 +30,6 @@ Additionally, participants who can submit scores on behalf of their team can als
 
 Refer to the [Actions to Consider](#actions-to-consider) section for more information.
 
-## User Guide
-
-### Moves
-
-In CITE, a move is a defined exercise period. During that period the system distributes events for users to discuss and assess the current incident severity.
-
-When in Dashboard view, users have two options for interacting with moves:
-
-- **Displayed Move:** Move currently shown on the screen. Here, users can see responses to previous moves and scores, but they cannot edit a response.
-- **Current Move:** Move that is currently active. In some cases the Displayed Move and the Current Move match. Here, users can edit the category of the move.
-
-### CITE Landing Page
-
-The CITE landing page provides a central approach to recompiling all evaluations that the user is a participant on into a single display.
-
-![CITE Landing Page OE](img/citeLandingPage-v2.png)
-
-#### Search for an Evaluation
-
-To search for an evaluation, follow these steps:
-
-1. Navigate to CITE's landing page.
-2. Click the Search Bar and add the name of the evaluation.
-
-### CITE Dashboard
-
-The CITE Dashboard shows exercise details like date and time, incident summary, a suggested list of actions for participants to consider taking, and suggested participant roles.
-
-The following image shows some important hotspots about the CITE Dashboard. Reference the number on the hotspot to learn more about this section.
-
-![CITE Dashboard OE](img/CITE-Dashboard-v3.png)
-
-#### Active Events & Moves
-
-##### Hotspot 1
-
-The name of the active event and the move number currently displayed.
-
-Once the user obtains Can Increment Move permission, the "Advance Move" button appears. This enables the user to advance CITE's current move, and go back and forth between moves using the arrows.
-
-![CITE Advance Move OE](img/advanceMoveButton.png)
-
-#### Situation Date & Time
-
-##### Hotspot 2
-
-The date and time of the situation displayed.
-
-#### Situation Description
-
-##### Hotspot 3
-
-Short description of the event. This section allows for the use of HTML elements, useful when receiving MSEL information from Blueprint.
-
-#### Actions to Consider
-
-##### Hotspot 4
-
-Users can see the different actions necessary to execute during the exercise. These actions are for everyone on the team and are "per move", changing at each move of the exercise.
-
-These actions guide users on an appropriate course of action during an exercise. However, these actions are not connected to the scoresheet.
-
-#### Roles
-
-##### Hotspot 5
-
-The roles give each team member a clear understanding of their responsibilities during the exercise. Roles are customizable per team, and the team members decide what role to assign to each user.
-
-#### Score Summary
-
-##### Hotspot 6
-
-Displays the various scores at the appropriate severity level for the displayed move. Here, scores are always visible.
-
-#### Team Selection
-
-##### Hotspot 7
-
-This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
-
-#### CITE Report Toggle
-
-##### Hotspot 8
-
-This feature redirects users to a printable version of the CITE report that recollects all user responses throughout the exercise.
-
-Refer to the [CITE Report](#cite-report) section for more information.
-
-#### Dashboard & Scoresheet Toggle
-
-##### Hotspot 9
-
-By using this icon, users can toggle between the CITE Dashboard and the CITE Scoresheet.
-
-### CITE Scoresheet
-
-The CITE Scoresheet compares participant scores to organization scores, group average scores, and the official score.
-
-The following image shows some important hotspots about the CITE Scoresheet. Reference the number on the hotspot to learn more about this section.
-
-![CITE Scoresheet OE](img/CITE-Scoresheet-v3.png)
-
-#### Event Name
-
-##### Hotspot 1
-
-The name of the current event.
-
-#### Displayed Move
-
-##### Hotspot 2
-
-The move currently displayed on the screen. Clicking < displays previous moves. Clicking > displays the current move. Using Displayed Move, users can see responses to previous moves and scores, but the user cannot edit a previous response.
-
-#### Scoring Features
-
-##### Hotspot 3
-
-- **User:** This is the participant's personal score for their reference only. The user score will also appear under the Score Summary range.
-- **Team:** Toggling the Team icon displays how the team scored this move so far. This is the score that the team collaborates on and submits for the current move. This score compares to the official score. The Team score appears under the Score Summary range.
-- **Team Avg:** The average for all of the users on the team. The Team Avg appears under the Score Summary range for all moves except the current move.
-- **Group Avg:** The average for all of the teams in the user's group. Group Avg appears under the Score Summary range for all moves except the current move.
-- **Official:** The potential score; that is, how the incident would score in a real-life scenario. Official score appears under the Score Summary range for all moves except the current move.
-- **Submit:** Submits the score, indicating that the user scored the current move. Click Yes or No. If the user clicks Yes but changes their mind, click Reopen to edit the scoring.
-- **Clear:** Clears any selections the user has checked but does not clear comments entered. Selecting Clear returns to a score of 0.00.
-- **Preset:** Sets the user's selections to the previous move score to use as a starting point for the current move.
-
-#### Categories and Options
-
-##### Hotspot 4
-
-Categories are individually scored based upon the current move situation. For each category, select one or more relevant options. Selecting options assigns points to each category, which compile to create the move score as defined by the [scoring model](#glossary).
-
-#### Add, Edit, and Delete a Comment
-
-When scoring a move, the user can attach a comment (or multiple comments) to a category.
-
-- To add a comment, click ![Comment OE](img/comment.png). Enter the comment and click Save.
-- To edit an existing comment, click ![Edit OE](img/edit.png). Make any changes, then click Save.
-- To delete an existing comment, click ![Trash OE](img/trash.png). Click Yes to delete the comment.
-
-When finished scoring the categories and adding comments, click Submit to submit the scores.
-
-#### Score Summary
-
-##### Hotspot 5
-
-The Score Summary panel displays the various scores at the appropriate severity level for the displayed move, keeping the data visible at all times.
-
-#### Team Selection
-
-##### Hotspot 6
-
-This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When the administrator assigns an observer role, the user can see other teams' progress during the exercise as well as participate on their own team.
-
-#### CITE Report Toggle
-
-##### Hotspot 7
-
-This feature redirects users to a printable version of the CITE report that recollects all user responses throughout the exercise.
-
-Refer to the [CITE Report](#cite-report) section for more information.
-
-#### Dashboard & Scoresheet Toggle
-
-##### Hotspot 8
-
-By using this icon, users can toggle between the CITE Dashboard and the CITE Scoresheet.
-
-### CITE Report
-
-The [CITE Report](#glossary) recollects all user responses into a single printable page. Users can reference this for their records, and exercise administrators can obtain valuable exercise insights from it.
-
-The following image shows the CITE Report. Here, users can view and/or print their own copy.
-
-![CITE Report OE](img/CITE-Report.png)
-
 ## Administrator Guide
 
 ## Administration View
@@ -764,6 +587,183 @@ To delete a user, follow these steps:
 1. Click the **Settings Cog**.
 2. Navigate to the **Users** tab.
 3. Select the users to delete and click the **Trash Can** next to the user.
+
+## User Guide
+
+### Moves
+
+In CITE, a move is a defined exercise period. During that period the system distributes events for users to discuss and assess the current incident severity.
+
+When in Dashboard view, users have two options for interacting with moves:
+
+- **Displayed Move:** Move currently shown on the screen. Here, users can see responses to previous moves and scores, but they cannot edit a response.
+- **Current Move:** Move that is currently active. In some cases the Displayed Move and the Current Move match. Here, users can edit the category of the move.
+
+### CITE Landing Page
+
+The CITE landing page provides a central approach to recompiling all evaluations that the user is a participant on into a single display.
+
+![CITE Landing Page OE](img/citeLandingPage-v2.png)
+
+#### Search for an Evaluation
+
+To search for an evaluation, follow these steps:
+
+1. Navigate to CITE's landing page.
+2. Click the Search Bar and add the name of the evaluation.
+
+### CITE Dashboard
+
+The CITE Dashboard shows exercise details like date and time, incident summary, a suggested list of actions for participants to consider taking, and suggested participant roles.
+
+The following image shows some important hotspots about the CITE Dashboard. Reference the number on the hotspot to learn more about this section.
+
+![CITE Dashboard OE](img/CITE-Dashboard-v3.png)
+
+#### Active Events & Moves
+
+##### Hotspot 1
+
+The name of the active event and the move number currently displayed.
+
+Once the user obtains Can Increment Move permission, the "Advance Move" button appears. This enables the user to advance CITE's current move, and go back and forth between moves using the arrows.
+
+![CITE Advance Move OE](img/advanceMoveButton.png)
+
+#### Situation Date & Time
+
+##### Hotspot 2
+
+The date and time of the situation displayed.
+
+#### Situation Description
+
+##### Hotspot 3
+
+Short description of the event. This section allows for the use of HTML elements, useful when receiving MSEL information from Blueprint.
+
+#### Actions to Consider
+
+##### Hotspot 4
+
+Users can see the different actions necessary to execute during the exercise. These actions are for everyone on the team and are "per move", changing at each move of the exercise.
+
+These actions guide users on an appropriate course of action during an exercise. However, these actions are not connected to the scoresheet.
+
+#### Roles
+
+##### Hotspot 5
+
+The roles give each team member a clear understanding of their responsibilities during the exercise. Roles are customizable per team, and the team members decide what role to assign to each user.
+
+#### Score Summary
+
+##### Hotspot 6
+
+Displays the various scores at the appropriate severity level for the displayed move. Here, scores are always visible.
+
+#### Team Selection
+
+##### Hotspot 7
+
+This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
+
+#### CITE Report Toggle
+
+##### Hotspot 8
+
+This feature redirects users to a printable version of the CITE report that recollects all user responses throughout the exercise.
+
+Refer to the [CITE Report](#cite-report) section for more information.
+
+#### Dashboard & Scoresheet Toggle
+
+##### Hotspot 9
+
+By using this icon, users can toggle between the CITE Dashboard and the CITE Scoresheet.
+
+### CITE Scoresheet
+
+The CITE Scoresheet compares participant scores to organization scores, group average scores, and the official score.
+
+The following image shows some important hotspots about the CITE Scoresheet. Reference the number on the hotspot to learn more about this section.
+
+![CITE Scoresheet OE](img/CITE-Scoresheet-v3.png)
+
+#### Event Name
+
+##### Hotspot 1
+
+The name of the current event.
+
+#### Displayed Move
+
+##### Hotspot 2
+
+The move currently displayed on the screen. Clicking < displays previous moves. Clicking > displays the current move. Using Displayed Move, users can see responses to previous moves and scores, but the user cannot edit a previous response.
+
+#### Scoring Features
+
+##### Hotspot 3
+
+- **User:** This is the participant's personal score for their reference only. The user score will also appear under the Score Summary range.
+- **Team:** Toggling the Team icon displays how the team scored this move so far. This is the score that the team collaborates on and submits for the current move. This score compares to the official score. The Team score appears under the Score Summary range.
+- **Team Avg:** The average for all of the users on the team. The Team Avg appears under the Score Summary range for all moves except the current move.
+- **Group Avg:** The average for all of the teams in the user's group. Group Avg appears under the Score Summary range for all moves except the current move.
+- **Official:** The potential score; that is, how the incident would score in a real-life scenario. Official score appears under the Score Summary range for all moves except the current move.
+- **Submit:** Submits the score, indicating that the user scored the current move. Click Yes or No. If the user clicks Yes but changes their mind, click Reopen to edit the scoring.
+- **Clear:** Clears any selections the user has checked but does not clear comments entered. Selecting Clear returns to a score of 0.00.
+- **Preset:** Sets the user's selections to the previous move score to use as a starting point for the current move.
+
+#### Categories and Options
+
+##### Hotspot 4
+
+Categories are individually scored based upon the current move situation. For each category, select one or more relevant options. Selecting options assigns points to each category, which compile to create the move score as defined by the [scoring model](#glossary).
+
+#### Add, Edit, and Delete a Comment
+
+When scoring a move, the user can attach a comment (or multiple comments) to a category.
+
+- To add a comment, click ![Comment OE](img/comment.png). Enter the comment and click Save.
+- To edit an existing comment, click ![Edit OE](img/edit.png). Make any changes, then click Save.
+- To delete an existing comment, click ![Trash OE](img/trash.png). Click Yes to delete the comment.
+
+When finished scoring the categories and adding comments, click Submit to submit the scores.
+
+#### Score Summary
+
+##### Hotspot 5
+
+The Score Summary panel displays the various scores at the appropriate severity level for the displayed move, keeping the data visible at all times.
+
+#### Team Selection
+
+##### Hotspot 6
+
+This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When the administrator assigns an observer role, the user can see other teams' progress during the exercise as well as participate on their own team.
+
+#### CITE Report Toggle
+
+##### Hotspot 7
+
+This feature redirects users to a printable version of the CITE report that recollects all user responses throughout the exercise.
+
+Refer to the [CITE Report](#cite-report) section for more information.
+
+#### Dashboard & Scoresheet Toggle
+
+##### Hotspot 8
+
+By using this icon, users can toggle between the CITE Dashboard and the CITE Scoresheet.
+
+### CITE Report
+
+The [CITE Report](#glossary) recollects all user responses into a single printable page. Users can reference this for their records, and exercise administrators can obtain valuable exercise insights from it.
+
+The following image shows the CITE Report. Here, users can view and/or print their own copy.
+
+![CITE Report OE](img/CITE-Report.png)
 
 ## Glossary
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -16,7 +16,7 @@ For installation, refer to these GitHub repositories.
 
 ## CITE Permissions
 
-In order to use CITE, an administrator assigns each user a scoring permission.
+To use CITE, an administrator assigns each user a scoring permission.
 
 There are three levels of permissions in CITE that shape how a team collaborates on and edits a score.
 
@@ -32,7 +32,9 @@ Refer to the [Actions to Consider](#actions-to-consider) section for more inform
 
 ## Administrator Guide
 
-## Administration View
+CITE administrators use the Administration View to manage users and configure evaluations, scoring models, scoring categories, actions, roles, and team types.
+
+### Administration View
 
 Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. The Administration View is where admins prepare and manage the environment so events run smoothly for participants.
 
@@ -41,13 +43,13 @@ Accessing the Administration View is the same in all Crucible exercise applicati
 ![The Administration dropdown in the top right-corner](img/crucible-administration.png)
 
 
-### Evaluations
+#### Evaluations
 
 The following image shows the Evaluations Administration Page. Here, administrators can add, edit, upload, download, copy, and delete [evaluations](#glossary).
 
 ![Evaluations Admin OE](img/EvaluationsAdmin-v4.png)
 
-#### Add an Evaluation
+##### Add an Evaluation
 
 If the exercise administrator grants the appropriate permissions, follow these steps to add an Evaluation.
 
@@ -56,7 +58,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 1. Under the Evaluation Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                      | Data Type     | Description                                                           | Example                                                    |
 | -------------------------- | ------------- | --------------------------------------------------------------------- | ---------------------------------------------------------- |
@@ -70,7 +72,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 
 To save these settings, click **Save**.
 
-#### Edit an Evaluation
+##### Edit an Evaluation
 
 To edit an evaluation, follow these steps:
 
@@ -80,7 +82,7 @@ To edit an evaluation, follow these steps:
 4. The system opens the same edit component used when creating a new evaluation.
 5. After making all necessary edits, click **Save**.
 
-#### Delete an Evaluation
+##### Delete an Evaluation
 
 To delete an evaluation, follow these steps:
 
@@ -88,7 +90,7 @@ To delete an evaluation, follow these steps:
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to delete and click the **Trash Can** next to the evaluation.
 
-#### Upload an Evaluation
+##### Upload an Evaluation
 
 To upload an evaluation, follow these steps:
 
@@ -97,7 +99,7 @@ To upload an evaluation, follow these steps:
 3. Click the **Up Arrow** next to the **+**.
 4. Select the evaluation JSON file to upload.
 
-#### Download an Evaluation
+##### Download an Evaluation
 
 To download an evaluation, follow these steps:
 
@@ -106,7 +108,7 @@ To download an evaluation, follow these steps:
 3. Click the **Down Arrow** next to the evaluation to download.
 4. Look for the JSON file in your Downloads folder.
 
-#### Copy an Evaluation
+##### Copy an Evaluation
 
 To copy an evaluation, follow these steps:
 
@@ -115,20 +117,20 @@ To copy an evaluation, follow these steps:
 3. Click **Copy** next to the evaluation to copy.
 4. Look for the evaluation name with the user's name.
 
-#### Configure an Evaluation
+##### Configure an Evaluation
 
 To configure an evaluation to use for an exercise, administrators will need to add moves and teams to the evaluation. To do this, follow these steps:
 
 ![Configure Evaluation OE](img/ConfigureEvaluations-v2.png)
 
-### Moves
+#### Moves
 
 ![Moves OE](img/moves-v3.png)
 
 1. Click **+** on the Moves section.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                     | Data Type | Description                                                     | Example                                 |
 | ------------------------- | --------- | --------------------------------------------------------------- | --------------------------------------- |
@@ -139,7 +141,7 @@ To configure an evaluation to use for an exercise, administrators will need to a
 
 To save these settings, click **Save**.
 
-#### Edit a Move
+##### Edit a Move
 
 To edit a move, follow these steps:
 
@@ -150,7 +152,7 @@ To edit a move, follow these steps:
 5. The system opens the same edit component used when creating a new move.
 6. After making all necessary edits, click **Save**.
 
-#### Delete a Move
+##### Delete a Move
 
 To delete a move, follow these steps:
 
@@ -159,14 +161,14 @@ To delete a move, follow these steps:
 3. Select the evaluation to edit and click the **Moves** tab.
 4. Select the move to delete and click the **Trash Can** next to the move.
 
-### Teams
+#### Teams
 
 ![Teams OE](img/teams-v3.png)
 
 1. Click **+** on the Teams section.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field               | Data Type     | Description                                                    | Example                    |
 | ------------------- | ------------- | -------------------------------------------------------------- | -------------------------- |
@@ -177,7 +179,7 @@ To delete a move, follow these steps:
 
 To save these settings, click **Save**.
 
-#### Edit a Team
+##### Edit a Team
 
 To edit a team, follow these steps:
 
@@ -188,7 +190,7 @@ To edit a team, follow these steps:
 5. The system opens the same edit component used when creating a new team.
 6. After making all necessary edits, click **Save**.
 
-#### Delete a Team
+##### Delete a Team
 
 To delete a team, follow these steps:
 
@@ -197,7 +199,7 @@ To delete a team, follow these steps:
 3. Select the evaluation to edit and click the **Teams** tab.
 4. Select the team to delete and click the **Trash Can** next to the team.
 
-### Observers
+#### Observers
 
 To assign the [Observer Role](#glossary) to a user:
 
@@ -209,13 +211,13 @@ To remove the Observer Role from a user:
 1. Under **Observers**, search for the desired user.
 2. After you find the user, click **Remove**.
 
-### Scoring Models
+#### Scoring Models
 
 The following image shows the [Scoring Models](#glossary) Administration Page. Here, administrators can add, edit, copy, download, upload, and delete scoring models.
 
 ![Scoring Models Admin OE](img/scoringModelsAdmin-v3.png)
 
-#### Add a Scoring Model
+##### Add a Scoring Model
 
 If the exercise administrator grants the appropriate permissions, follow these steps to add a Scoring Model.
 
@@ -224,7 +226,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 1. Under the Scoring Model Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                                         | Data Type     | Description                                                                        | Example               |
 | --------------------------------------------- | ------------- | ---------------------------------------------------------------------------------- | --------------------- |
@@ -257,7 +259,7 @@ Aside from these variables, use **>** to set clipping values for the equation.
 
 - **Example:** 100 > equation > 20 will constrain the value of the submission between 100 and 20.
 
-#### Edit a Scoring Model
+##### Edit a Scoring Model
 
 To edit a scoring model, follow these steps:
 
@@ -267,7 +269,7 @@ To edit a scoring model, follow these steps:
 4. The system opens the same edit component used when creating a new scoring model.
 5. After making all necessary edits, click **Save**.
 
-#### Upload a Scoring Model
+##### Upload a Scoring Model
 
 To upload a scoring model, follow these steps:
 
@@ -276,7 +278,7 @@ To upload a scoring model, follow these steps:
 3. Click the **Up Arrow** next to the **+**.
 4. Select the scoring model JSON file to upload.
 
-#### Download a Scoring Model
+##### Download a Scoring Model
 
 To download a scoring model, follow these steps:
 
@@ -285,7 +287,7 @@ To download a scoring model, follow these steps:
 3. Click the **Down Arrow** next to the scoring model to download.
 4. Look for the JSON file in your Downloads folder.
 
-#### Copy a Scoring Model
+##### Copy a Scoring Model
 
 To copy a scoring model, follow these steps:
 
@@ -294,7 +296,7 @@ To copy a scoring model, follow these steps:
 3. Click **Copy** next to the scoring model to copy.
 4. Look for the scoring model name with the user's name.
 
-#### Delete a Scoring Model
+##### Delete a Scoring Model
 
 To delete a scoring model, follow these steps:
 
@@ -302,7 +304,7 @@ To delete a scoring model, follow these steps:
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to delete and click the **Trash Can** next to the scoring model.
 
-### Scoring Categories
+#### Scoring Categories
 
 To configure a Scoring Model to use for an exercise, administrators will need to add [Scoring Categories](#glossary).
 
@@ -310,14 +312,14 @@ Within a Scoring Model, an administrator can add one or more Scoring Categories.
 
 ![Configure Scoring Model OE](img/configureScoringModel.png)
 
-#### Add Scoring Category
+##### Add Scoring Category
 
 ![Scoring Categories OE](img/scoringCategories-v3.png)
 
 1. Click **+** on the Scoring Categories section.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                             | Data Type     | Description                                                                                      | Example            |
 | --------------------------------- | ------------- | ------------------------------------------------------------------------------------------------ | ------------------ |
@@ -344,7 +346,7 @@ Additionally, a Scoring Category has an admin defined equation to calculate the 
 
 Last but not least, a Scoring Category has a weight by which to multiply the score obtained from the entered equation.
 
-#### Edit a Scoring Category
+##### Edit a Scoring Category
 
 To edit a scoring category, follow these steps:
 
@@ -355,27 +357,27 @@ To edit a scoring category, follow these steps:
 5. The system opens the same edit component used when creating a new scoring category.
 6. After making all necessary edits, click **Save**.
 
-#### Delete a Scoring Category
+##### Delete a Scoring Category
 
-To delete a scoring model, follow these steps:
+To delete a scoring category, follow these steps:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
 4. Select the scoring category to delete and click the **Trash Can** next to the scoring category.
 
-### Scoring Options
+#### Scoring Options
 
 Within a Scoring Category, an administrator can add one or more [Scoring Options](#glossary). To do this, follow these steps:
 
-#### Add Scoring Options
+##### Add Scoring Options
 
 ![Scoring Options OE](img/scoringOptions.png)
 
 1. Click **+** on the Scoring Options section.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                          | Data Type | Description                                                         | Example   |
 | ------------------------------ | --------- | ------------------------------------------------------------------- | --------- |
@@ -386,7 +388,7 @@ Within a Scoring Category, an administrator can add one or more [Scoring Options
 
 To save these settings, click **Save**.
 
-#### Edit a Scoring Option
+##### Edit a Scoring Option
 
 To edit a scoring option, follow these steps:
 
@@ -398,7 +400,7 @@ To edit a scoring option, follow these steps:
 6. The system opens the same edit component used when creating a new scoring option.
 7. After making all necessary edits, click **Save**.
 
-#### Delete a Scoring Option
+##### Delete a Scoring Option
 
 To delete a scoring option, follow these steps:
 
@@ -408,7 +410,7 @@ To delete a scoring option, follow these steps:
 4. Select the scoring category to edit and click the **Scoring Options** tab.
 5. Select the scoring option to delete and click the **Trash Can** next to the scoring option.
 
-### Actions
+#### Actions
 
 The following image shows the Actions Administration Page. Here, administrators can add, edit, and delete actions.
 
@@ -416,7 +418,7 @@ However, users who can submit scores on behalf of their team can also add sugges
 
 ![Actions Admin OE](img/actionsAdmin-v2.png)
 
-#### Add an Action
+##### Add an Action
 
 If the exercise administrator grants the appropriate permissions, follow these steps to add an Action.
 
@@ -427,7 +429,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 3. Click **+** to add an Action.
 4. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                  | Data Type | Description                                            | Example       |
 | ---------------------- | --------- | ------------------------------------------------------ | ------------- |
@@ -435,7 +437,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 
 To save these settings, click **Save**.
 
-#### Edit an Action
+##### Edit an Action
 
 To edit an action, follow these steps:
 
@@ -445,7 +447,7 @@ To edit an action, follow these steps:
 4. The system opens the same edit component used when creating a new action.
 5. After making all necessary edits, click **Save**.
 
-#### Delete an Action
+##### Delete an Action
 
 To delete an action, follow these steps:
 
@@ -453,7 +455,7 @@ To delete an action, follow these steps:
 2. Navigate to the **Action** tab.
 3. Select the action to delete and click the **Trash Can** next to the action.
 
-### Roles
+#### Roles
 
 The following image shows the Roles Administration Page. Here, administrators can add, edit, and delete roles.
 
@@ -461,7 +463,7 @@ However, users who can submit scores on behalf of their team can also add partic
 
 ![Roles Admin OE](img/rolesAdmin-v2.png)
 
-#### Add a Role
+##### Add a Role
 
 If the exercise administrator grants the appropriate permissions, follow these steps to add a Role:
 
@@ -471,7 +473,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 2. Click **+** to add a Role.
 3. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field         | Data Type | Description      | Example   |
 | ------------- | --------- | ---------------- | --------- |
@@ -479,7 +481,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 
 To save these settings, click **Save**.
 
-#### Edit a Role
+##### Edit a Role
 
 To edit a role, follow these steps:
 
@@ -489,7 +491,7 @@ To edit a role, follow these steps:
 4. The system opens the same edit component used when creating a new role.
 5. After making all necessary edits, click **Save**.
 
-#### Delete a Role
+##### Delete a Role
 
 To delete a role, follow these steps:
 
@@ -497,7 +499,7 @@ To delete a role, follow these steps:
 2. Navigate to the **Roles** tab.
 3. Select the role to delete and click the **Trash Can** next to the role.
 
-### Submissions
+#### Submissions
 
 The following image shows the Submissions Administration Page. Here, administrators can keep track of all score [submissions](#glossary) provided by the different teams during an exercise. This allows administrators to compare their scores with the official score, as well as keep track of which teams are on a good track and which are not.
 
@@ -505,13 +507,13 @@ Additional functionalities include copying the entire score, as well as deleting
 
 ![Submissions Admin OE](img/submissionsAdmin-v2.png)
 
-### Team Types
+#### Team Types
 
 The following image shows the [Team Types](#glossary) Administration Page. Here, administrators can create different types of teams to use during an exercise. This allows administrators to classify the different teams on the platform based on common characteristics and/or organizations.
 
 ![Team Types Admin OE](img/teamTypesAdmin.png)
 
-#### Add a Team Type
+##### Add a Team Type
 
 If the exercise administrator grants the appropriate permissions, follow these steps to add a Team Type:
 
@@ -520,7 +522,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 1. Under the Team Type Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                          | Data Type | Description                                                           | Example                 |
 | ------------------------------ | --------- | --------------------------------------------------------------------- | ----------------------- |
@@ -530,7 +532,7 @@ If the exercise administrator grants the appropriate permissions, follow these s
 
 To save these settings, click **Save**.
 
-#### Edit a Team Type
+##### Edit a Team Type
 
 To edit a team type, follow these steps:
 
@@ -540,7 +542,7 @@ To edit a team type, follow these steps:
 4. The system opens the same edit component used when creating a new team type.
 5. After making all necessary edits, click **Save**.
 
-#### Delete a Team Type
+##### Delete a Team Type
 
 To delete a team type, follow these steps:
 
@@ -548,30 +550,30 @@ To delete a team type, follow these steps:
 2. Navigate to the **Team Types** tab.
 3. Select the team type to delete and click the **Trash Can** next to the team type.
 
-### Users
+#### Users
 
-The following image shows the *Users Administration* page. Here, administrators can add and delete users, and assign the necessary permissions to each user.
+The following image shows the Users Administration page. Here, administrators can add and delete users, and assign the necessary permissions to each user.
 
 The available permissions are:
 
-- **System Admin:** Permission that will grant a user all administration privileges on the CITE application.
-- **Content Developer:** Receives permission to manage other CITE admin pages except the Users Admin page and their permissions.
-- **Can Submit:** This permission lets the user submit a score for the different moves during an exercise.
-- **Can Modify:** This permission lets the user modify a score for previous moves during an exercise.
-- **Can Increment Move:** Grant this permission to allow the user to increment the current move during an exercise.
+- **System Admin:** Grants a user all administration privileges on the CITE application.
+- **Content Developer:** Can manage other CITE admin pages except the Users Admin page and their permissions.
+- **Can Submit:** Lets the user submit a score for the different moves during an exercise.
+- **Can Modify:** Lets the user modify a score for previous moves during an exercise.
+- **Can Increment Move:** Lets the user increment the current move during an exercise.
 
 ![Users Admin OE](img/usersAdmin-v2.png)
 
-#### Add a User
+##### Add a User
 
-Assuming that the exercise administrator granted the user the appropriate permissions, follow these steps to add a User:
+If the exercise administrator grants the appropriate permissions, follow these steps to add a user:
 
 ![Add User OE](img/addUser-v2.png)
 
 1. Under the Users Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field         | Data Type | Description                        | Example                              |
 | ------------- | --------- | ---------------------------------- | ------------------------------------ |
@@ -580,7 +582,7 @@ Assuming that the exercise administrator granted the user the appropriate permis
 
 To save these settings, click **Save** and select the desired permissions to assign by checking the boxes next to the user.
 
-#### Delete a User
+##### Delete a User
 
 To delete a user, follow these steps:
 

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -14,213 +14,6 @@ For installation, refer to these GitHub repositories.
 - [Gallery UI Repository](https://github.com/cmu-sei/Gallery.Ui)
 - [Gallery API Repository](https://github.com/cmu-sei/Gallery.Api)
 
-## User Guide
-
-### Gallery Landing Page
-
-The Gallery landing page provides a central approach to recompiling all collections and exhibits that the user is a participant on into a single display.
-
-![Gallery Landing Page OE](img/galleryLandingPage.png)
-
-First, users select a collection from the dropdown; then, they choose an exhibit from the displayed list.
-
-#### Search for an Exhibit
-
-To search for an exhibit, follow these steps:
-
-1. Navigate to Gallery's landing page.
-2. Select a collection from the dropdown.
-3. Click the **Search Bar** and add the name of the creator of the exhibit.
-
-### Gallery Wall
-
-The Gallery Wall is a dashboard with red, orange, yellow, and green status indicators. Each of these cards has a specific set of actions, which helps users throughout the in-game exercise.
-
-- **Red:** Indicates a closed status.
-- **Orange:** Indicates a critical status.
-- **Yellow:** Indicates an affected status.
-- **Green:** Indicates an open status.
-
-The following image shows some important hotspots about the Gallery Wall. Reference the number on the hotspot to learn more about this section.
-
-![Gallery Wall OE](img/galleryWall-v2.png)
-
-#### Title
-
-##### Hotspot 1
-
-The title of the card.
-
-#### Description
-
-##### Hotspot 2
-
-A brief description of the event.
-
-#### Date Posted
-
-##### Hotspot 3
-
-The date and time the card was last updated.
-
-#### Unread Articles
-
-##### Hotspot 4
-
-The number of [articles](#glossary) left to read from the event.
-
-#### Details
-
-##### Hotspot 5
-
-Provides additional details beyond those provided in the Gallery Wall, including filtered articles related to the event.
-
-#### Team Selection
-
-##### Hotspot 6
-
-This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
-
-#### Wall & Archive Toggle
-
-##### Hotspot 7
-
-By using this icon, users can toggle between the Gallery Wall and Gallery Archive.
-
-### Gallery Archive
-
-The Gallery Archive is a collection of information that contains relevant reporting, intelligence, news, and social media data sources.
-
-The following image shows some important hotspots about the Gallery Archive. Reference the number on the hotspot to learn more about this section.
-
-![Gallery Archive OE](img/galleryArchive-v2.png)
-
-#### Add an Article
-
-##### Hotspot 1
-
-Users assigned the appropriate permissions can add articles to the Archive related to the exercise's current events.
-
-To add an article, refer to the [Add Articles During an Exercise](#add-articles-during-an-exercise) section.
-
-#### Search
-
-##### Hotspot 2
-
-The archive contains all "move" data that teams have shared up to this point in the exercise. Users can search, sort, and filter information in the archive.
-
-To search the archive, enter the terms in the **Search the Archive** field. The search feature automatically narrows down the results.
-
-#### Cards Filter
-
-##### Hotspot 3
-
-Users can use this dropdown to further filter intelligence information. Users can sort the Gallery articles based on their card categories. This is useful for users who are searching for information from a specific category.
-
-#### Source Filters
-
-##### Hotspot 4
-
-These articles come from different categories of sources: [reporting](#glossary), [news](#glossary), [orders](#glossary), [phone](#glossary), [email](#glossary), [intel](#glossary), and [social media](#glossary). Users can select one or multiple filters to display only the cards that belong to those filter categorizations.
-
-#### Article Information
-
-##### Hotspot 5
-
-The Gallery Archive displays articles. Each article contains the Title, Source Type, Source Name, and Date Posted.
-
-For the information included on the article:
-
-- **Title:** The title of the intelligence report.
-- **Source Type:** The source of the intelligence report (News, Intel, Reporting, or Social Media).
-- **Source Name:** The specific person or agency who supplied the intelligence.
-- **Date Posted:** The date and timestamp when the intelligence report posted.
-
-#### View
-
-##### Hotspot 6
-
-View the full article in a pop-up page or open the article in a new tab for better visualization.
-
-#### Read
-
-##### Hotspot 7
-
-After reading an article, mark it as read to keep track of new articles.
-
-#### Share
-
-##### Hotspot 8
-
-With this feature, users can share an article with others using a mail service.
-
-To share an article with another team, click **Share**. In the **Share Article** screen:
-
-1. Under **Share with...**, select a team.
-2. Under **Email Contents...**, make any edits to the Subject and Message of the article.
-3. Click **Share**.
-
-#### More
-
-##### Hotspot 9
-
-When enabled, the system provides attached documents with additional information for users to access and read.
-
-#### Team Selection
-
-##### Hotspot 10
-
-This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
-
-#### Wall & Archive Toggle
-
-##### Hotspot 11
-
-By using this icon, users can toggle between the Gallery Wall and Gallery Archive.
-
-### Add Articles During an Exercise
-
-Users with the appropriate Content Developer permissions can add articles to the Gallery Archive throughout the course of exercise events.
-
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add an article during an exercise:
-
-![Add Articles Exercise OE](img/addArticleExercise.png)
-
-1. On the Gallery Archive section, click **+** to add an article.
-2. Fill the fields as necessary following the Data Format Table specifications.
-
-#### Data Format Table
-
-| Field                   | Data Type     | Description                                                 | Example                                                                                 |
-| ----------------------- | ------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| **Name**                | String        | Name of the article                                         | No cell phone connectivity                                                              |
-| **Summary**             | String        | Short summary of the article                                | No cell phone connectivity after pass of Hurricane Delta                                |
-| **Description**         | Rich Text     | Description with characteristics and details of the article | In a world driven by constant connectivity, the sudden absence of cell phone signals... |
-| **Url for more info**   | String        | If additional details are necessary, provide the URL        | `www.bbcnews.com/hurricane-delta`                                                       |
-| **Open URL in new tab** | Boolean       | Select this option to open the URL in a new tab             | True                                                                                    |
-| **Card**                | Dropdown Text | Article's classification amongst Gallery cards              | Communications Sector                                                                   |
-| **Status**              | Dropdown Text | Status of how the article affects the exercise situation    | Affected                                                                                |
-
-To save these settings, click **Save**.
-
-After you create your article, the Gallery Archive displays it in the following way.
-
-![Article Created OE](img/createdArticle.png)
-
-#### Edit an Article
-
-To edit an article, follow these steps:
-
-1. On the Gallery Archive section, select the article to edit and click **Edit** on the article's card.
-2. The system opens the same edit component used when creating a new article.
-3. After making all necessary edits, click **Save**.
-
-#### Delete an Article
-
-To delete an article, follow these steps:
-
-1. On the Gallery Archive section, select the article to delete and click the **Trash Can** on the article's card.
-
 ## Administrator Guide
 
 ## Administration View
@@ -597,6 +390,213 @@ To remove the Observer Role from a user:
 
 1. Under **Observers**, search for the desired user.
 2. After you find the user, click **Remove**.
+
+## User Guide
+
+### Gallery Landing Page
+
+The Gallery landing page provides a central approach to recompiling all collections and exhibits that the user is a participant on into a single display.
+
+![Gallery Landing Page OE](img/galleryLandingPage.png)
+
+First, users select a collection from the dropdown; then, they choose an exhibit from the displayed list.
+
+#### Search for an Exhibit
+
+To search for an exhibit, follow these steps:
+
+1. Navigate to Gallery's landing page.
+2. Select a collection from the dropdown.
+3. Click the **Search Bar** and add the name of the creator of the exhibit.
+
+### Gallery Wall
+
+The Gallery Wall is a dashboard with red, orange, yellow, and green status indicators. Each of these cards has a specific set of actions, which helps users throughout the in-game exercise.
+
+- **Red:** Indicates a closed status.
+- **Orange:** Indicates a critical status.
+- **Yellow:** Indicates an affected status.
+- **Green:** Indicates an open status.
+
+The following image shows some important hotspots about the Gallery Wall. Reference the number on the hotspot to learn more about this section.
+
+![Gallery Wall OE](img/galleryWall-v2.png)
+
+#### Title
+
+##### Hotspot 1
+
+The title of the card.
+
+#### Description
+
+##### Hotspot 2
+
+A brief description of the event.
+
+#### Date Posted
+
+##### Hotspot 3
+
+The date and time the card was last updated.
+
+#### Unread Articles
+
+##### Hotspot 4
+
+The number of [articles](#glossary) left to read from the event.
+
+#### Details
+
+##### Hotspot 5
+
+Provides additional details beyond those provided in the Gallery Wall, including filtered articles related to the event.
+
+#### Team Selection
+
+##### Hotspot 6
+
+This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
+
+#### Wall & Archive Toggle
+
+##### Hotspot 7
+
+By using this icon, users can toggle between the Gallery Wall and Gallery Archive.
+
+### Gallery Archive
+
+The Gallery Archive is a collection of information that contains relevant reporting, intelligence, news, and social media data sources.
+
+The following image shows some important hotspots about the Gallery Archive. Reference the number on the hotspot to learn more about this section.
+
+![Gallery Archive OE](img/galleryArchive-v2.png)
+
+#### Add an Article
+
+##### Hotspot 1
+
+Users assigned the appropriate permissions can add articles to the Archive related to the exercise's current events.
+
+To add an article, refer to the [Add Articles During an Exercise](#add-articles-during-an-exercise) section.
+
+#### Search
+
+##### Hotspot 2
+
+The archive contains all "move" data that teams have shared up to this point in the exercise. Users can search, sort, and filter information in the archive.
+
+To search the archive, enter the terms in the **Search the Archive** field. The search feature automatically narrows down the results.
+
+#### Cards Filter
+
+##### Hotspot 3
+
+Users can use this dropdown to further filter intelligence information. Users can sort the Gallery articles based on their card categories. This is useful for users who are searching for information from a specific category.
+
+#### Source Filters
+
+##### Hotspot 4
+
+These articles come from different categories of sources: [reporting](#glossary), [news](#glossary), [orders](#glossary), [phone](#glossary), [email](#glossary), [intel](#glossary), and [social media](#glossary). Users can select one or multiple filters to display only the cards that belong to those filter categorizations.
+
+#### Article Information
+
+##### Hotspot 5
+
+The Gallery Archive displays articles. Each article contains the Title, Source Type, Source Name, and Date Posted.
+
+For the information included on the article:
+
+- **Title:** The title of the intelligence report.
+- **Source Type:** The source of the intelligence report (News, Intel, Reporting, or Social Media).
+- **Source Name:** The specific person or agency who supplied the intelligence.
+- **Date Posted:** The date and timestamp when the intelligence report posted.
+
+#### View
+
+##### Hotspot 6
+
+View the full article in a pop-up page or open the article in a new tab for better visualization.
+
+#### Read
+
+##### Hotspot 7
+
+After reading an article, mark it as read to keep track of new articles.
+
+#### Share
+
+##### Hotspot 8
+
+With this feature, users can share an article with others using a mail service.
+
+To share an article with another team, click **Share**. In the **Share Article** screen:
+
+1. Under **Share with...**, select a team.
+2. Under **Email Contents...**, make any edits to the Subject and Message of the article.
+3. Click **Share**.
+
+#### More
+
+##### Hotspot 9
+
+When enabled, the system provides attached documents with additional information for users to access and read.
+
+#### Team Selection
+
+##### Hotspot 10
+
+This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
+
+#### Wall & Archive Toggle
+
+##### Hotspot 11
+
+By using this icon, users can toggle between the Gallery Wall and Gallery Archive.
+
+### Add Articles During an Exercise
+
+Users with the appropriate Content Developer permissions can add articles to the Gallery Archive throughout the course of exercise events.
+
+Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add an article during an exercise:
+
+![Add Articles Exercise OE](img/addArticleExercise.png)
+
+1. On the Gallery Archive section, click **+** to add an article.
+2. Fill the fields as necessary following the Data Format Table specifications.
+
+#### Data Format Table
+
+| Field                   | Data Type     | Description                                                 | Example                                                                                 |
+| ----------------------- | ------------- | ----------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| **Name**                | String        | Name of the article                                         | No cell phone connectivity                                                              |
+| **Summary**             | String        | Short summary of the article                                | No cell phone connectivity after pass of Hurricane Delta                                |
+| **Description**         | Rich Text     | Description with characteristics and details of the article | In a world driven by constant connectivity, the sudden absence of cell phone signals... |
+| **Url for more info**   | String        | If additional details are necessary, provide the URL        | `www.bbcnews.com/hurricane-delta`                                                       |
+| **Open URL in new tab** | Boolean       | Select this option to open the URL in a new tab             | True                                                                                    |
+| **Card**                | Dropdown Text | Article's classification amongst Gallery cards              | Communications Sector                                                                   |
+| **Status**              | Dropdown Text | Status of how the article affects the exercise situation    | Affected                                                                                |
+
+To save these settings, click **Save**.
+
+After you create your article, the Gallery Archive displays it in the following way.
+
+![Article Created OE](img/createdArticle.png)
+
+#### Edit an Article
+
+To edit an article, follow these steps:
+
+1. On the Gallery Archive section, select the article to edit and click **Edit** on the article's card.
+2. The system opens the same edit component used when creating a new article.
+3. After making all necessary edits, click **Save**.
+
+#### Delete an Article
+
+To delete an article, follow these steps:
+
+1. On the Gallery Archive section, select the article to delete and click the **Trash Can** on the article's card.
 
 ## Glossary
 

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -16,7 +16,9 @@ For installation, refer to these GitHub repositories.
 
 ## Administrator Guide
 
-## Administration View
+Gallery administrators use the Administration View to manage users, collections, cards, articles, and exhibits.
+
+### Administration View
 
 Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. The Administration View is where admins prepare and manage the environment so events run smoothly for participants.
 
@@ -25,29 +27,29 @@ Accessing the Administration View is the same in all Crucible exercise applicati
 ![The Administration dropdown in the top right-corner](img/crucible-administration.png)
 
 
-### Users
+#### Users
 
 The following image shows the Users Administration Page. Here, administrators can add and delete users, and assign the necessary permissions to each user.
 
 The available permissions are:
 
-- [System Admin](#glossary): Permission that will grant a user all administration privileges on the Gallery application.
-- [Content Developer](#glossary): Permission to manage other Gallery admin pages except the Users admin page and their permissions.
+- [System Admin](#glossary): Grants a user all administration privileges on the Gallery application.
+- [Content Developer](#glossary): Can manage other Gallery admin pages except the Users admin page and their permissions.
 
 Most users won't have any permissions assigned in this application.
 
 ![Gallery Users Admin OE](img/galleryUsersAdmin.png)
 
-#### Add a User
+##### Add a User
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add a user:
+If the exercise administrator grants the appropriate permissions, follow these steps to add a user:
 
 ![Add Gallery User OE](img/addGalleryUser-v2.png)
 
 1. Under the Users Administration View, click **Add User**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field     | Data Type | Description                               | Example                              |
 | --------- | --------- | ----------------------------------------- | ------------------------------------ |
@@ -57,7 +59,7 @@ Assuming that the exercise administrator grants the user the appropriate permiss
 
 To save these settings, click **Save** and select the desired permissions to assign by checking the box next to the user.
 
-#### Edit User's Information
+##### Edit User's Information
 
 To edit a user, follow these steps:
 
@@ -67,7 +69,7 @@ To edit a user, follow these steps:
 4. The system opens the same edit component used when creating a new user.
 5. After making all necessary edits, click **Save**.
 
-#### Delete a User
+##### Delete a User
 
 To delete a user, follow these steps:
 
@@ -75,22 +77,22 @@ To delete a user, follow these steps:
 2. Navigate to the **Users** tab.
 3. Select the user to delete and click the **Trash Can** next to the user.
 
-### Collections
+#### Collections
 
 The following image shows the Collections Administration Page. Here, administrators can add, upload, download, copy, and delete [collections](#glossary). Assign articles here, in case multiple exercises are running at the same time.
 
 ![Collections Admin OE](img/collectionsAdmin-v2.png)
 
-#### Add a Collection
+##### Add a Collection
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add a collection:
+If the exercise administrator grants the appropriate permissions, follow these steps to add a collection:
 
 ![Add Collection OE](img/addCollection-v2.png)
 
 1. Under the Collections Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field           | Data Type | Description                                                | Example                                         |
 | --------------- | --------- | ---------------------------------------------------------- | ----------------------------------------------- |
@@ -99,7 +101,7 @@ Assuming that the exercise administrator grants the user the appropriate permiss
 
 To save these settings, click **Save**.
 
-#### Edit a Collection
+##### Edit a Collection
 
 To edit a collection, follow these steps:
 
@@ -109,7 +111,7 @@ To edit a collection, follow these steps:
 4. The system opens the same edit component used when creating a new collection.
 5. After making all necessary edits, click **Save**.
 
-#### Delete a Collection
+##### Delete a Collection
 
 To delete a collection, follow these steps:
 
@@ -117,48 +119,48 @@ To delete a collection, follow these steps:
 2. Navigate to the **Collections** tab.
 3. Select the collection you plan to delete and click the **Trash Can Icon** next to the collection.
 
-#### Upload a Collection
+##### Upload a Collection
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to upload a collection:
+If the exercise administrator grants the appropriate permissions, follow these steps to upload a collection:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Collections** tab.
 3. Click the **Up Arrow** next to the **+**.
 4. Select the collection JSON file you want to upload.
 
-#### Download a Collection
+##### Download a Collection
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to download a collection:
+If the exercise administrator grants the appropriate permissions, follow these steps to download a collection:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Collections** tab.
 3. Click the **Down Arrow** next to the collection and download the JSON file.
 4. Open your Downloads folder to confirm it finished downloading.
 
-#### Copy a Collection
+##### Copy a Collection
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to copy a collection:
+If the exercise administrator grants the appropriate permissions, follow these steps to copy a collection:
 
 1. Click the **Settings Cog**.
 2. Navigate to the **Collections** tab.
 3. Click **Copy** next to the collection and review the new entry that includes your username.
 
-### Cards
+#### Cards
 
 The following image shows the Cards Administration Page. Here, administrators can add and delete cards. Each card appears in the Gallery Wall and stores articles related to that card.
 
 ![Cards Admin OE](img/cardsAdmin.png)
 
-#### Add a Card
+##### Add a Card
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add a card:
+If the exercise administrator grants the appropriate permissions, follow these steps to add a card:
 
 ![Add Card OE](img/addCard-v2.png)
 
 1. Under the Cards Administration View, click **Add Card**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field           | Data Type     | Description                                          | Example                                                             |
 | --------------- | ------------- | ---------------------------------------------------- | ------------------------------------------------------------------- |
@@ -168,7 +170,7 @@ Assuming that the exercise administrator grants the user the appropriate permiss
 
 To save these settings, click **Save**.
 
-#### Edit a Card
+##### Edit a Card
 
 To edit a card, follow these steps:
 
@@ -178,7 +180,7 @@ To edit a card, follow these steps:
 4. The system opens the same edit component used when creating a new card.
 5. After making all necessary edits, click **Save**.
 
-#### Delete a Card
+##### Delete a Card
 
 To delete a card, follow these steps:
 
@@ -186,22 +188,22 @@ To delete a card, follow these steps:
 2. Navigate to the **Cards** tab.
 3. Select the card to delete and click the **Trash Can** next to the card.
 
-### Articles
+#### Articles
 
 The following image shows the Articles Administration Page. Here, administrators can add and delete articles. These articles provide supplemental information from different sources to keep the exercise going.
 
 ![Articles Admin OE](img/articlesAdmin.png)
 
-#### Add an Article
+##### Add an Article
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add an article:
+If the exercise administrator grants the appropriate permissions, follow these steps to add an article:
 
 ![Add Article OE](img/addArticle-v2.png)
 
 1. Under the Article Administration View, click **Add Article**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                   | Data Type     | Description                                                    | Example                                                                          |
 | ----------------------- | ------------- | -------------------------------------------------------------- | -------------------------------------------------------------------------------- |
@@ -220,7 +222,7 @@ Assuming that the exercise administrator grants the user the appropriate permiss
 
 To save these settings, click **Save**.
 
-#### Edit an Article
+##### Edit an Article
 
 To edit an article, follow these steps:
 
@@ -230,7 +232,7 @@ To edit an article, follow these steps:
 4. The system opens the same edit component used when creating a new article.
 5. After making all necessary edits, click **Save**.
 
-#### Delete an Article
+##### Delete an Article
 
 To delete an article, follow these steps:
 
@@ -238,22 +240,22 @@ To delete an article, follow these steps:
 2. Navigate to the **Articles** tab.
 3. Select the article to delete and click the **Trash Can** next to the article.
 
-### Exhibits
+#### Exhibits
 
 The following image shows the Exhibits Administration Page. Here, administrators configure the actual exercise and run it based on the teams, collections, and articles they previously configured.
 
 ![Exhibits Admin OE](img/exhibitsAdmin-v3.png)
 
-#### Add an Exhibit
+##### Add an Exhibit
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add an [exhibit](#glossary):
+If the exercise administrator grants the appropriate permissions, follow these steps to add an [exhibit](#glossary):
 
 ![Add Exhibit OE](img/addExhibit-v2.png)
 
 1. Under the Exhibit Administration View, click **+**.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field              | Data Type | Description                          | Example                               |
 | ------------------ | --------- | ------------------------------------ | ------------------------------------- |
@@ -263,7 +265,7 @@ Assuming that the exercise administrator grants the user the appropriate permiss
 
 To save these settings, click **Save**.
 
-#### Edit an Exhibit
+##### Edit an Exhibit
 
 To edit an exhibit, follow these steps:
 
@@ -273,7 +275,7 @@ To edit an exhibit, follow these steps:
 4. The system opens the same edit component used when creating a new exhibit.
 5. After making all necessary edits, click **Save**.
 
-#### Delete an Exhibit
+##### Delete an Exhibit
 
 To delete an exhibit, follow these steps:
 
@@ -281,7 +283,7 @@ To delete an exhibit, follow these steps:
 2. Navigate to the **Exhibits** tab.
 3. Select the exhibit to delete and click the **Trash Can** next to the exhibit.
 
-#### Upload an Exhibit
+##### Upload an Exhibit
 
 To upload an exhibit, follow these steps:
 
@@ -294,7 +296,7 @@ To upload an exhibit, follow these steps:
 
     When you add a new exhibit, the system creates a new collection with the uploaded exhibit. To view the uploaded exhibit, navigate to the collection using the dropdown and select the collection with the same name as the file you uploaded.
 
-#### Download an Exhibit
+##### Download an Exhibit
 
 To download an exhibit, follow these steps:
 
@@ -303,7 +305,7 @@ To download an exhibit, follow these steps:
 3. Click the **Down Arrow** next to the exhibit and download the JSON file.
 4. Open your Downloads folder to confirm it finished downloading.
 
-#### Copy an Exhibit
+##### Copy an Exhibit
 
 To copy an exhibit, follow these steps:
 
@@ -311,13 +313,13 @@ To copy an exhibit, follow these steps:
 2. Navigate to the **Exhibits** tab.
 3. Click **Copy** next to the exhibit and review the new entry that includes your username.
 
-#### Configure an Exhibit
+##### Configure an Exhibit
 
-To configure an exhibit for an exercise, administrators will need to add Exhibit Teams, Card Teams, Article Teams, as well as assign the respective Observers (if desired). To do this, follow these steps:
+To configure an exhibit for an exercise, administrators add Exhibit Teams, Card Teams, and Article Teams, and assign Observers if desired. To do this, follow these steps:
 
 ![Configure Exhibit OE](img/configureExhibit-v2.png)
 
-#### Add a Team to an Exhibit
+##### Add a Team to an Exhibit
 
 To add a team to the Exhibit, follow these steps:
 
@@ -326,7 +328,7 @@ To add a team to the Exhibit, follow these steps:
 1. Click the **+** icon.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field          | Data Type | Description                                | Example                    |
 | -------------- | --------- | ------------------------------------------ | -------------------------- |
@@ -345,7 +347,7 @@ To configure a team, follow these steps:
 3. Under the **Team Users** tab, review the users who already belong to the team. To remove a user from the team, click **Remove**.
 4. If desired, check the **Observer** box to assign that role to the user during the exercise.
 
-#### Add a Team Card to an Exhibit
+##### Add a Team Card to an Exhibit
 
 To add a Team Card to the Exhibit, follow these steps:
 
@@ -354,7 +356,7 @@ To add a Team Card to the Exhibit, follow these steps:
 1. Click **+** on the Card Teams section.
 2. Fill the fields as necessary following the Data Format Table specifications.
 
-#### Data Format Table
+##### Data Format Table
 
 | Field                     | Data Type     | Description                                                              | Example                          |
 | ------------------------- | ------------- | ------------------------------------------------------------------------ | -------------------------------- |
@@ -367,7 +369,7 @@ To add a Team Card to the Exhibit, follow these steps:
 
 To save these settings, click **Save**.
 
-#### Add an Article to a Team
+##### Add an Article to a Team
 
 To add an article to a team, follow these steps:
 
@@ -377,7 +379,7 @@ To add an article to a team, follow these steps:
 2. Under the **Exhibit Teams** tab, identify the teams without an article assignment. To add them to the Article Teams, click **Add**.
 3. Under the **Article Teams** tab, review the teams that already have assignments. To remove a team, click **Remove**.
 
-#### The Observer Role
+##### The Observer Role
 
 To assign the [Observer Role](#glossary) to a user:
 
@@ -559,7 +561,7 @@ By using this icon, users can toggle between the Gallery Wall and Gallery Archiv
 
 Users with the appropriate Content Developer permissions can add articles to the Gallery Archive throughout the course of exercise events.
 
-Assuming that the exercise administrator grants the user the appropriate permissions, follow these steps to add an article during an exercise:
+If the exercise administrator grants the appropriate permissions, follow these steps to add an article during an exercise:
 
 ![Add Articles Exercise OE](img/addArticleExercise.png)
 
@@ -608,7 +610,7 @@ This glossary defines key terms and concepts used in the Gallery application.
 
 **Collection**: A set of articles.
 
-**Content Developer Permission**: Will grant a user the ability to manage other Gallery administration pages, except the users administration page and their permissions.
+**Content Developer Permission**: Grants a user the ability to manage other Gallery administration pages, except the users administration page and their permissions.
 
 **Email Filter**: Information gathered from messages distributed by electronic means.
 


### PR DESCRIPTION
- Moved the User Guide to come after the Administrator Guide in Blueprint, CITE, and Gallery to match the standard structure used by other Crucible apps.
- Added intro paragraphs to the empty `## Administrator Guide` sections in all three apps
- Demoted `## Administration View` to `### Administration View` to match the pattern used by Player and Caster
- ` Promoted `### Blueprint Permissions` to a standalone `## Blueprint Permissions` section to match CITE pattern
- Fixed grammar and inconsistencies in all three Administrator Guide sections