### PR TITLE
Promoted Blueprint Permissions to standalone top-level section

### DIFF
--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -11,7 +11,7 @@ For installation, refer to these GitHub repositories.
 - [Blueprint UI Repository](https://github.com/cmu-sei/Blueprint.Ui)
 - [Blueprint API Repository](https://github.com/cmu-sei/Blueprint.Api)
 
-### Blueprint Permissions
+## Blueprint Permissions
 
 To use Blueprint, a System Admin must assign Content Developer permissions to the user and add them to a team.
 


### PR DESCRIPTION
Matches the pattern used by CITE, where permissions appear as a top-level section between Overview and Administrator Guide.