### PR TITLE
Fix empty heading sections and Font Awesome icons across core app guides

### DIFF
--- a/docs/alloy/index.md
+++ b/docs/alloy/index.md
@@ -6,6 +6,8 @@ An **Alloy** Definition brings together a Player View, a Caster Directory, and a
 
 ## Permissions and Roles
 
+Alloy controls access through a combination of permissions and roles. Permissions define what users can do; roles group permissions and apply them to users globally or per resource.
+
 ### Permissions
 
 Sets of *permissions* govern access to features of Alloy. Permissions can apply globally or per Event Template/Event. Examples of global permissions include:
@@ -97,6 +99,8 @@ The Alloy user interface as viewed by a user consists of two screens:
     There is no error reporting when launching an event template or lab. If an error occurs, the user is returned to the Launch screen.
 
 ### Deploy an Event/Exercise
+
+This section covers how to create an Alloy definition and deploy an event or exercise, including the launch and end processes.
 
 #### How to Create an Alloy Definition
 

--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -330,6 +330,8 @@ To search for a specific CITE role template, follow these steps:
 
 ## User Guide
 
+Content developers use Blueprint to build and manage MSELs.
+
 ### Blueprint Landing Page
 
 The landing page of Blueprint provides a variety of interaction modalities for exercises, tailored according to the permissions assigned to each user. The functionalities available are as follows:

--- a/docs/caster/index.md
+++ b/docs/caster/index.md
@@ -16,6 +16,8 @@ The [Crucible Terraform Provider](https://registry.terraform.io/providers/cmu-se
 
 ## Administrator Guide
 
+Caster administrators use the Administration View to manage users, roles, and VLANs.
+
 ### Administration View
 
 Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. It is where admins prepare and manage the environment so events run smoothly for participants.

--- a/docs/caster/index.md
+++ b/docs/caster/index.md
@@ -216,7 +216,7 @@ Administrators can create new groups, search for and edit existing groups, and d
 
 ## User Guide
 
-Administrators manage the environment, including projects, users, groups, permissions, modules, and running workspaces in the Administration area. Users access assigned projects, create and edit Terraform files, and deploy configurations to workspaces. This *User Guide* explains how you, the user, perform those tasks.
+Users access assigned projects, create and edit Terraform files, and deploy configurations to workspaces.
 
 ### Project
 
@@ -235,9 +235,11 @@ Add Directory lets you create a new directory at the same level as the above pro
 
 #### Export Project
 
-Export Projects allows you to export the project as a zip file.
+Export Project lets you export the project as an archive file. Select the **Archive Type** (default: Zip), then click **Export**. Enable **Include Ids** to include directory IDs in the export.
 
 #### Import Project
+
+Import Project lets you import a project from a zip file. Click **Choose File** to select the zip file, then click **Import**. Enable **Preserve Ids** to append IDs to directory names during the import.
 
 ### Files
 
@@ -299,6 +301,8 @@ Designer provides a graphical user interface for creating and editing terraform 
 When you open a project, you can create a design and add modules backed by Git to that design. You can also create variables for use in the modules settings.
 
 ## Caster Tips
+
+The following tips help you get the most out of Caster.
 
 ### Crafting Terraform Code
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -592,6 +592,8 @@ To delete a user, follow these steps:
 
 ## User Guide
 
+Participants use the CITE Dashboard and Scoresheet to evaluate and score incidents during an exercise.
+
 ### Moves
 
 In CITE, a move is a defined exercise period. During that period the system distributes events for users to discuss and assess the current incident severity.

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -395,6 +395,8 @@ To remove the Observer Role from a user:
 
 ## User Guide
 
+Participants use the Gallery Wall and Archive to track and respond to exercise events.
+
 ### Gallery Landing Page
 
 The Gallery landing page provides a central approach to recompiling all collections and exhibits that the user is a participant on into a single display.

--- a/docs/player/index.md
+++ b/docs/player/index.md
@@ -118,6 +118,8 @@ In the dropdown next to your username, select **Administration**.
 
 ### Roles and Permissions
 
+Player controls access through a combination of permissions and roles. Permissions grant specific capabilities globally or per view; roles group permissions and apply them to users.
+
 #### Permissions
 
 Sets of *permissions* control access to features in Player. Permissions can apply globally or per **View**.
@@ -362,6 +364,8 @@ Receive and read notifications here.
 
 ## Player Tips
 
+The following tips help you get the most out of Player.
+
 ### Taking Advantage of Screen Real Estate
 
 Player and its component applications (as well as any third-party application linked through Player) can use any monitor setup. You can open any application in the application bar in a new window or tab by clicking the [>] button on the right side of the application card. You can also open virtual machine consoles in a new window or tab. This setup gives you flexibility in how you display information in Player. For example, you can view documentation or a lab guide on one monitor while using your virtual machine on another. You can use multiple windows with an ultra-wide monitor to see everything at once.
@@ -402,6 +406,8 @@ The procedures below show you how to remotely power a VM on or off from within t
 2. On the VM tab, click the **gear icon**, then **Power**. You have the menu options to Power On, Power Off, and Reboot.
 
 ### Uploading Files
+
+Player's VM Console app supports file transfers between your local machine and virtual machines.
 
 #### Upload from local to VM
 

--- a/docs/player/index.md
+++ b/docs/player/index.md
@@ -18,6 +18,8 @@ Player is *not* meant to:
 
 ## Administrator Guide
 
+Player administrators use the Administration View to manage views, teams, applications, users, and roles.
+
 ### Administration View
 
 Across the Crucible exercise applications, the **Administration View** is where privileged users configure the platform and control access. It includes user and team management, role and permission assignment, and setup and maintenance of app-specific templates and content. The Administration View is where admins prepare and manage the environment so events run smoothly for participants.

--- a/docs/steamfitter/index.md
+++ b/docs/steamfitter/index.md
@@ -19,6 +19,8 @@ Behind the scenes, Steamfitter uses [StackStorm](https://stackstorm.com/) to exe
 
 ## Permissions and Roles
 
+Steamfitter controls access through a combination of permissions and roles. Permissions define what users can do; roles group permissions and apply them to users globally or per resource.
+
 ### Permissions
 
 Sets of *permissions* control access to features in Steamfitter. Permissions apply globally or per Scenario Template or Scenario.
@@ -53,7 +55,7 @@ Users who have the `ManageRoles` permission can create custom system roles in th
 
 ## Administrator Guide
 
-The *Steamfitter Administrator Guide* covers the configuration and management of the Steamfitter app. Administrators use the Administration View to manage users, assign roles and permissions, and maintain scenario templates. This guide walks through the key areas of the Administration View and the tools available for setting up and managing Steamfitter content.
+Steamfitter administrators use the Administration View to manage users, assign roles and permissions, and maintain scenario templates.
 
 ### Administration View
 

--- a/docs/topomojo/index.md
+++ b/docs/topomojo/index.md
@@ -16,6 +16,8 @@ Go to the TopoMojo repository: [github.com/cmu-sei/TopoMojo](https://github.com/
 
 ## TopoMojo Concepts
 
+Understanding the key concepts in TopoMojo helps you build and manage labs and challenges effectively.
+
 ### Workspace and Gamespace
 
 In a *workspace*, engineers add VMs, save updates, author guides, and configure questions/answers to turn the topology into a lab or challenge.
@@ -45,9 +47,7 @@ Third-party consumers of TopoMojo content, like [Gameboard](../gameboard/index.m
 
 ## Getting Started
 
-### What's New
-
-Get the latest TopoMojo source code and its accompanying release notes from the [GitHub repository](https://github.com/cmu-sei/TopoMojo).
+The following sections cover how to install TopoMojo and configure it for your environment.
 
 ### Installing
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ site_url: https://cmu-sei.github.io/crucible/
 copyright: >
   Copyright &copy; 2025-2026 Carnegie Mellon University. All rights reserved.
 extra_css:
+  - https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.7.2/css/all.min.css
   - https://fonts.googleapis.com/icon?family=Material+Icons
   - stylesheets/extra.css
 theme:


### PR DESCRIPTION
- Added intro paragraphs to empty heading sections in Player, Caster, Steamfitter, Alloy, Blueprint, CITE, Gallery, and TopoMojo
- Removed the "What's New" section from the TopoMojo guide
- Added Font Awesome CDN to `mkdocs.yml` so inline icon tags render correctly on the TopoMojo page