### PR TITLE
Added `no-empty-sections` lint rule and refactored hotspot headings

### DIFF
--- a/.github/linting/no-empty-sections.js
+++ b/.github/linting/no-empty-sections.js
@@ -1,0 +1,40 @@
+// Custom markdownlint rule: no-empty-sections
+// Flags any heading immediately followed by another heading with no content between them.
+
+module.exports = {
+  names: ["no-empty-sections"],
+  description: "Headings must have content before the next heading",
+  tags: ["headings"],
+  function: function rule(params, onError) {
+    // Only apply this rule to files under docs/
+    if (!params.name.includes("/docs/")) {
+      return;
+    }
+
+    const tokens = params.tokens;
+    let lastHeadingOpen = null;
+    let hasContent = false;
+
+    for (const token of tokens) {
+      if (token.type === "heading_open") {
+        // If we just saw a heading and found no content before this next heading, flag it
+        // Skip H1 headings — a page title with no body before the first section is intentional
+        if (lastHeadingOpen !== null && !hasContent && lastHeadingOpen.tag !== "h1") {
+          onError({
+            lineNumber: lastHeadingOpen.lineNumber,
+            detail: `Heading on line ${lastHeadingOpen.lineNumber} has no content before the next heading on line ${token.lineNumber}`,
+          });
+        }
+        lastHeadingOpen = token;
+        hasContent = false;
+      } else if (
+        token.type !== "heading_close" &&
+        token.type !== "inline" &&
+        lastHeadingOpen !== null
+      ) {
+        // Any token that isn't part of the heading itself counts as content
+        hasContent = true;
+      }
+    }
+  },
+};

--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -5,6 +5,9 @@
 ignores:
   - LICENSE.md
 
+customRules:
+  - .github/linting/no-empty-sections.js
+
 config:
   # Do not allow headings to increase more than 1 level at a time
   MD001: true

--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -390,85 +390,70 @@ To end an event, follow these steps:
 
 ### MSEL Catalog
 
-The MSEL Catalog shows created MSELs. Here, users are able to select the desired MSEL to work on, as well as create or delete them.
+The MSEL Catalog shows created MSELs. Users can select a MSEL to work on, create a new one, and delete an existing one.
 
-The following image shows some important hotspots about the MSEL Catalog. Reference the number on the hotspot to learn more about this section.
-
+<!-- TODO: Replace screenshot with version without numbered callout markers -->
 ![Blueprint Dashboard OE](img/blueprintDashboard-v4.png)
 
 #### Add Blank MSEL
-
-##### Hotspot 1
 
 Blueprint lets users create a MSEL from scratch directly in the application. This removes the hassle of Excel and makes visualizing information easier.
 
 #### Upload an Existing MSEL
 
-##### Hotspot 2
-
-If creating a new MSEL from scratch is not desired, users can upload a pre-existing MSEL and continue editing it on the application by using this functionality. This is useful to share existing MSEL work without having to add the pieces of information to a blank MSEL one by one.
+Users can upload a pre-existing MSEL and continue editing it in the application. This is useful to share existing MSEL work without having to add information to a blank MSEL one by one.
 
 #### Filter Display
 
+Use the filter options to narrow down MSELs shown in the catalog.
+
 ##### Types
 
-###### Hotspot 3
-
-Users can apply this filter to narrow down MSELs presented on the dashboard based on their categorization. Selections available are: All Types, Templates, and Not Templates.
+Filter MSELs by categorization. Options are: All Types, Templates, and Not Templates.
 
 ##### Statuses
 
-###### Hotspot 4
-
-Users can apply this filter to narrow down MSELs presented on the dashboard based on their current status. Selections available are: All Statuses, Pending, Entered, Approved, and Completed.
+Filter MSELs by current status. Options are: All Statuses, Pending, Entered, Approved, and Completed.
 
 ##### Search
 
-##### Hotspot 5
-
-This functionality enables users to search for a specific MSEL, in case it is not presented at the top on the dashboard.
+Search for a specific MSEL by name.
 
 #### Load All MSELs
 
-##### Hotspot 6
-
-This functionality enables users with the proper administrative permissions to load and view all MSELs created.
+Users with the appropriate administrative permissions can load and view all MSELs created.
 
 #### Settings Cog
 
-##### Hotspot 7
-
-Users with the proper administrative permissions can use this feature to access Blueprint's administrative settings.
+Users with the appropriate administrative permissions can use the Settings Cog to access Blueprint's administrative settings.
 
 #### Manage MSEL
 
-##### Hotspot 8
+Click a MSEL card to open it. The following actions are available from the MSEL card.
 
 #### Download
 
-Users can download a copy of any MSEL for offline use using the Download feature. This is useful if they lack internet access, allowing them to work on the MSEL offline and upload changes later. However, offline work is not recommended as users will miss Blueprint's features and updates.
+Users can download a copy of any MSEL for offline use. Offline work is not recommended as users will miss Blueprint's features and updates.
 
 #### Upload
 
-With the Upload feature, users can update the information from the MSEL Card with the new uploaded information. This feature will modify all the existing information with the one found on the .xlsx file.
+The Upload feature updates the MSEL card with information from a new `.xlsx` file, replacing all existing content.
 
 !!! important
 
-    When engaging in the export and import process of MSELs from the Blueprint application, it is imperative to ensure that events and settings of the MSEL align with your particular preferences. It is worth noting that on occasion, during the import process of MSELs into the application, it may be necessary to reconfigure settings and specific fields.
+    When importing MSELs into Blueprint, verify that events and settings align with your preferences. Some fields may require reconfiguration after import.
 
 #### Delete
 
-The Delete feature lets users remove existing MSEL cards including all associated information.
+The Delete feature removes an existing MSEL card and all associated information.
 
 #### Copy
 
-The Copy feature lets users duplicate an existing MSEL Card and modify the copy instead of the original. This helps when unsure about new changes or starting from a known reference.
+The Copy feature duplicates an existing MSEL card. Use this to modify a copy instead of the original.
 
 #### MSEL Cards
 
-##### Hotspot 9
-
-Click a MSEL card to view its information. Users can also edit or update the existing information, and changes appear live for others without needing to share a new document.
+Click a MSEL card to view its information. Users can edit or update existing information, and changes appear live for all collaborators.
 
 ### MSEL Definition
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -620,13 +620,10 @@ To search for an evaluation, follow these steps:
 
 The CITE Dashboard shows exercise details like date and time, incident summary, a suggested list of actions for participants to consider taking, and suggested participant roles.
 
-The following image shows some important hotspots about the CITE Dashboard. Reference the number on the hotspot to learn more about this section.
-
+<!-- TODO: Replace screenshot with version without numbered callout markers -->
 ![CITE Dashboard OE](img/CITE-Dashboard-v3.png)
 
 #### Active Events & Moves
-
-##### Hotspot 1
 
 The name of the active event and the move number currently displayed.
 
@@ -636,19 +633,13 @@ Once the user obtains Can Increment Move permission, the "Advance Move" button a
 
 #### Situation Date & Time
 
-##### Hotspot 2
-
 The date and time of the situation displayed.
 
 #### Situation Description
 
-##### Hotspot 3
-
 Short description of the event. This section allows for the use of HTML elements, useful when receiving MSEL information from Blueprint.
 
 #### Actions to Consider
-
-##### Hotspot 4
 
 Users can see the different actions necessary to execute during the exercise. These actions are for everyone on the team and are "per move", changing at each move of the exercise.
 
@@ -656,25 +647,17 @@ These actions guide users on an appropriate course of action during an exercise.
 
 #### Roles
 
-##### Hotspot 5
-
 The roles give each team member a clear understanding of their responsibilities during the exercise. Roles are customizable per team, and the team members decide what role to assign to each user.
 
 #### Score Summary
-
-##### Hotspot 6
 
 Displays the various scores at the appropriate severity level for the displayed move. Here, scores are always visible.
 
 #### Team Selection
 
-##### Hotspot 7
-
 This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
 
 #### CITE Report Toggle
-
-##### Hotspot 8
 
 This feature redirects users to a printable version of the CITE report that recollects all user responses throughout the exercise.
 
@@ -682,33 +665,24 @@ Refer to the [CITE Report](#cite-report) section for more information.
 
 #### Dashboard & Scoresheet Toggle
 
-##### Hotspot 9
-
 By using this icon, users can toggle between the CITE Dashboard and the CITE Scoresheet.
 
 ### CITE Scoresheet
 
 The CITE Scoresheet compares participant scores to organization scores, group average scores, and the official score.
 
-The following image shows some important hotspots about the CITE Scoresheet. Reference the number on the hotspot to learn more about this section.
-
+<!-- TODO: Replace screenshot with version without numbered callout markers -->
 ![CITE Scoresheet OE](img/CITE-Scoresheet-v3.png)
 
 #### Event Name
-
-##### Hotspot 1
 
 The name of the current event.
 
 #### Displayed Move
 
-##### Hotspot 2
-
 The move currently displayed on the screen. Clicking < displays previous moves. Clicking > displays the current move. Using Displayed Move, users can see responses to previous moves and scores, but the user cannot edit a previous response.
 
 #### Scoring Features
-
-##### Hotspot 3
 
 - **User:** This is the participant's personal score for their reference only. The user score will also appear under the Score Summary range.
 - **Team:** Toggling the Team icon displays how the team scored this move so far. This is the score that the team collaborates on and submits for the current move. This score compares to the official score. The Team score appears under the Score Summary range.
@@ -720,8 +694,6 @@ The move currently displayed on the screen. Clicking < displays previous moves. 
 - **Preset:** Sets the user's selections to the previous move score to use as a starting point for the current move.
 
 #### Categories and Options
-
-##### Hotspot 4
 
 Categories are individually scored based upon the current move situation. For each category, select one or more relevant options. Selecting options assigns points to each category, which compile to create the move score as defined by the [scoring model](#glossary).
 
@@ -737,27 +709,19 @@ When finished scoring the categories and adding comments, click Submit to submit
 
 #### Score Summary
 
-##### Hotspot 5
-
 The Score Summary panel displays the various scores at the appropriate severity level for the displayed move, keeping the data visible at all times.
 
 #### Team Selection
 
-##### Hotspot 6
-
 This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When the administrator assigns an observer role, the user can see other teams' progress during the exercise as well as participate on their own team.
 
 #### CITE Report Toggle
-
-##### Hotspot 7
 
 This feature redirects users to a printable version of the CITE report that recollects all user responses throughout the exercise.
 
 Refer to the [CITE Report](#cite-report) section for more information.
 
 #### Dashboard & Scoresheet Toggle
-
-##### Hotspot 8
 
 By using this icon, users can toggle between the CITE Dashboard and the CITE Scoresheet.
 

--- a/docs/gallery/index.md
+++ b/docs/gallery/index.md
@@ -422,49 +422,34 @@ The Gallery Wall is a dashboard with red, orange, yellow, and green status indic
 - **Yellow:** Indicates an affected status.
 - **Green:** Indicates an open status.
 
-The following image shows some important hotspots about the Gallery Wall. Reference the number on the hotspot to learn more about this section.
-
+<!-- TODO: Replace screenshot with version without numbered callout markers -->
 ![Gallery Wall OE](img/galleryWall-v2.png)
 
 #### Title
-
-##### Hotspot 1
 
 The title of the card.
 
 #### Description
 
-##### Hotspot 2
-
 A brief description of the event.
 
 #### Date Posted
-
-##### Hotspot 3
 
 The date and time the card was last updated.
 
 #### Unread Articles
 
-##### Hotspot 4
-
 The number of [articles](#glossary) left to read from the event.
 
 #### Details
-
-##### Hotspot 5
 
 Provides additional details beyond those provided in the Gallery Wall, including filtered articles related to the event.
 
 #### Team Selection
 
-##### Hotspot 6
-
 This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
 
 #### Wall & Archive Toggle
-
-##### Hotspot 7
 
 By using this icon, users can toggle between the Gallery Wall and Gallery Archive.
 
@@ -472,13 +457,10 @@ By using this icon, users can toggle between the Gallery Wall and Gallery Archiv
 
 The Gallery Archive is a collection of information that contains relevant reporting, intelligence, news, and social media data sources.
 
-The following image shows some important hotspots about the Gallery Archive. Reference the number on the hotspot to learn more about this section.
-
+<!-- TODO: Replace screenshot with version without numbered callout markers -->
 ![Gallery Archive OE](img/galleryArchive-v2.png)
 
 #### Add an Article
-
-##### Hotspot 1
 
 Users assigned the appropriate permissions can add articles to the Archive related to the exercise's current events.
 
@@ -486,27 +468,19 @@ To add an article, refer to the [Add Articles During an Exercise](#add-articles-
 
 #### Search
 
-##### Hotspot 2
-
 The archive contains all "move" data that teams have shared up to this point in the exercise. Users can search, sort, and filter information in the archive.
 
 To search the archive, enter the terms in the **Search the Archive** field. The search feature automatically narrows down the results.
 
 #### Cards Filter
 
-##### Hotspot 3
-
 Users can use this dropdown to further filter intelligence information. Users can sort the Gallery articles based on their card categories. This is useful for users who are searching for information from a specific category.
 
 #### Source Filters
 
-##### Hotspot 4
-
 These articles come from different categories of sources: [reporting](#glossary), [news](#glossary), [orders](#glossary), [phone](#glossary), [email](#glossary), [intel](#glossary), and [social media](#glossary). Users can select one or multiple filters to display only the cards that belong to those filter categorizations.
 
 #### Article Information
-
-##### Hotspot 5
 
 The Gallery Archive displays articles. Each article contains the Title, Source Type, Source Name, and Date Posted.
 
@@ -519,19 +493,13 @@ For the information included on the article:
 
 #### View
 
-##### Hotspot 6
-
 View the full article in a pop-up page or open the article in a new tab for better visualization.
 
 #### Read
 
-##### Hotspot 7
-
 After reading an article, mark it as read to keep track of new articles.
 
 #### Share
-
-##### Hotspot 8
 
 With this feature, users can share an article with others using a mail service.
 
@@ -543,19 +511,13 @@ To share an article with another team, click **Share**. In the **Share Article**
 
 #### More
 
-##### Hotspot 9
-
 When enabled, the system provides attached documents with additional information for users to access and read.
 
 #### Team Selection
 
-##### Hotspot 10
-
 This feature enables a user who is part of a team, as well as an observer, to toggle back and forth between teams. When assigned an observer role, the user can see other teams' progress during the exercise, as well as participate on their own team.
 
 #### Wall & Archive Toggle
-
-##### Hotspot 11
 
 By using this icon, users can toggle between the Gallery Wall and Gallery Archive.
 

--- a/docs/gameboard/index.md
+++ b/docs/gameboard/index.md
@@ -114,6 +114,8 @@ The Game Center header displays game metadata and settings, including the name, 
 
 ### Gear Tab
 
+The Gear tab contains the core settings for your game, organized into the sections below.
+
 #### Metadata
 
 **Name:** The title of your game. Displayed in the game lobby and on the scoreboard.
@@ -215,6 +217,8 @@ Offering a different execution period from registration period is an option. Thi
 **Registration Markdown:** Using Markdown enter any information you would like players to see when they register for the game. For help with Markdown syntax, see this [Markdown Guide](https://www.markdownguide.org/).
 
 ### Challenges Tab
+
+Use the Challenges tab to add challenges from TopoMojo to your game.
 
 #### Search
 
@@ -558,6 +562,8 @@ A challenge remains current and not archived until the **Reset Session** button 
 
 ### Support Settings
 
+The Support Settings section configures the support experience for participants during the game.
+
 #### Greeting
 
 In the **Greeting** field, enter a message. Your message appears as a banner on the Support page to welcome players. Customize it to fit your needs. The field supports the use of Markdown formatting.
@@ -822,6 +828,8 @@ This section assumes that you already hold the Administrator role in Gameboard, 
 
 ## User Guide
 
+Participants use Gameboard to register for games, play challenges, track scores, and get support during competitions.
+
 ### The Profile Screen
 
 Participants access their *Profile* by browsing to the Gameboard's designated URL and logging in. By default, authenticated participants land in the Profile screen if they haven't registered for a game yet. Otherwise, click **Profile** in the top navigation.
@@ -829,6 +837,8 @@ Participants access their *Profile* by browsing to the Gameboard's designated UR
 ![profile link in nav](img/profile-profile.png)
 
 #### Profile Tab
+
+The Profile tab is where participants set their display name and manage their account settings.
 
 ##### Display Name
 
@@ -1059,6 +1069,8 @@ Gameboard administrators configure global Practice Area settings including: a pr
 The Gameboard platform comes with a built-in customer support interface so that competition hosts and administrators can assist players and teams. Gameboard is a "one-stop shop" and you don't need outside apps or systems to track and measure issues reported by participants. Users who hold a role with the appropriate permissions can use the support feature to manage tickets.
 
 #### Support from the Participant Point-of-View
+
+Participants can create and track support tickets from within Gameboard.
 
 ##### Creating New Support Ticket
 

--- a/docs/roles/administrator/deployment/index.md
+++ b/docs/roles/administrator/deployment/index.md
@@ -18,6 +18,8 @@ The *Installation Guide* includes example configurations and links to the [k3s-i
 
 ## Understanding Deployment Architecture
 
+The following sections describe the core services and supporting infrastructure that make up a Crucible deployment.
+
 ### Core Services
 
 Crucible's architecture consists of:
@@ -32,6 +34,8 @@ See the [Infrastructure Administrator Guide](../index.md) for more information.
 
 ## Managing Configuration
 
+The following sections cover application configuration and Helm chart values.
+
 ### Configuring Applications
 
 Each Crucible application has specific configuration requirements documented in its GitHub repository:
@@ -44,6 +48,8 @@ Each Crucible application has specific configuration requirements documented in 
 Helm chart values for each application are available in the [helm-charts repository](https://github.com/cmu-sei/helm-charts).
 
 ## Scaling and Optimizing Performance
+
+The following sections cover horizontal and vertical scaling strategies and resource optimization.
 
 ### Planning for Scaling
 
@@ -60,6 +66,8 @@ Monitor resource utilization through:
 - Storage usage via Longhorn (if installed)
 
 ## Monitoring and Troubleshooting Deployments
+
+The following sections cover monitoring system health and resolving common deployment issues.
 
 ### Monitoring System Health
 

--- a/docs/roles/administrator/index.md
+++ b/docs/roles/administrator/index.md
@@ -28,6 +28,8 @@ Refer to the following documentation for application-specific permission details
 
 ## Platform Architecture
 
+The following sections describe the core components and supporting services that make up the Crucible platform.
+
 ### Core Components
 
 ```text

--- a/docs/roles/administrator/system-operations/index.md
+++ b/docs/roles/administrator/system-operations/index.md
@@ -13,6 +13,8 @@ System operations for Crucible include:
 
 ## Monitoring and Alerting
 
+The following sections cover monitoring Kubernetes, application health, infrastructure, and logs.
+
 ### Monitoring Kubernetes
 
 Monitor Crucible using standard Kubernetes tools:
@@ -55,6 +57,8 @@ Track the following cluster metrics:
 
 ## Performing Maintenance
 
+The following sections cover updating applications, maintaining databases, and managing backups and recovery.
+
 ### Updating Applications
 
 Update Crucible applications using Helm:
@@ -85,6 +89,8 @@ Perform regular PostgreSQL maintenance:
 
 ### Managing Backups and Recovery
 
+The following sections cover backup strategies and recovery procedures.
+
 #### Backup Strategy
 
 - Databases: Schedule PostgreSQL backups using `pg_dump` or equivalent tools
@@ -100,6 +106,8 @@ Restore services as needed:
 - Application recovery using Helm and backed-up values files
 
 ## Managing Performance and Scale
+
+The following sections cover resource tuning and scaling Crucible applications.
 
 ### Managing Resources
 
@@ -129,6 +137,8 @@ Most Crucible services support horizontal scaling:
 Refer to the [Installation Guide](../../../install/index.md#postgresql-and-pgadmin) for minimum hardware requirements and scaling considerations.
 
 ## Troubleshooting Operations
+
+The following sections cover common issues and diagnostic commands.
 
 ### Addressing Common Issues
 
@@ -162,6 +172,8 @@ kubectl get events -A --sort-by='.lastTimestamp'
 ```
 
 ## Managing Security Operations
+
+The following sections cover security monitoring and incident response.
 
 ### Monitoring Security
 

--- a/docs/roles/administrator/user-management/index.md
+++ b/docs/roles/administrator/user-management/index.md
@@ -39,6 +39,8 @@ See the individual application permission documentation linked above for complet
 
 ## Managing User Accounts
 
+The following sections cover creating users, managing permissions, and managing teams.
+
 ### Creating Users
 
 Create and manage users through your identity provider (Keycloak or IdentityServer):
@@ -57,8 +59,6 @@ Grant permissions within Crucible applications as follows:
 3. Assign application-specific permissions according to the relevant permission documentation.
 4. Use application APIs to manage permissions in bulk, if needed.
 
-### Team Management
-
 ### Managing Teams
 
 The **Player** application supports team management for organizing users into collaborative groups during exercises:
@@ -69,6 +69,8 @@ The **Player** application supports team management for organizing users into co
 - Refer to the [Player Guide](../../../player/index.md) for detailed team management procedures.
 
 ## Security Considerations
+
+The following sections cover access control best practices and audit logging.
 
 ### Access Control Best Practices
 
@@ -89,6 +91,8 @@ Enable audit logging in each Crucible application to record:
 Configure audit log forwarding to your Security Information and Event Management (SIEM) system as described in the [Security and Compliance Checklist](../security/index.md).
 
 ## User Workflows by Role
+
+The following sections describe the typical permissions required for each Crucible user role.
 
 ### Range Builders
 

--- a/docs/roles/range-builder/assessment/index.md
+++ b/docs/roles/range-builder/assessment/index.md
@@ -27,6 +27,8 @@ Monitor participant progress throughout scenarios:
 
 ## Testing and Validation
 
+The following sections cover a scenario testing checklist and common issues to watch for before going live.
+
 ### Scenario Testing Checklist
 
 - All task dependencies resolve correctly
@@ -37,6 +39,8 @@ Monitor participant progress throughout scenarios:
 - Assessment points are fair and measurable
 
 ### Common Issues and Solutions
+
+The following sections describe common problems and how to address them.
 
 #### Timing Problems
 

--- a/docs/roles/range-builder/index.md
+++ b/docs/roles/range-builder/index.md
@@ -52,6 +52,8 @@ Range structure varies based on training goals, audience, and available resource
 
 ## Best Practices
 
+The following sections cover recommended practices for infrastructure design, scenario design, and content development.
+
 ### Infrastructure Design
 
 - Use modular Terraform configurations

--- a/docs/roles/range-builder/infrastructure/index.md
+++ b/docs/roles/range-builder/infrastructure/index.md
@@ -6,6 +6,8 @@ The [Crucible Terraform Provider](https://registry.terraform.io/providers/cmu-se
 
 ## Best Practices
 
+The following sections cover recommended practices for organizing projects, directories, and Terraform configurations.
+
 ### Projects and Directories
 
 - **Projects:** Top-level organizational containers
@@ -208,6 +210,8 @@ Domain Controller Module
     ```
 
 ## Summary of Best Practices
+
+The following sections summarize key practices for configuration management, security, and performance.
 
 ### Configuration Management
 

--- a/docs/roles/range-builder/quick-start.md
+++ b/docs/roles/range-builder/quick-start.md
@@ -27,6 +27,8 @@ Before starting, confirm the following:
 
 ## Step 1: Create the Infrastructure (Caster) ~15 minutes
 
+In Step 1, you create the infrastructure in Caster: a project, a directory, and three Terraform files that define a 3-VM topology.
+
 ### Create a Project and Directory
 
 1. Navigate to Caster, **Projects**.
@@ -187,6 +189,8 @@ data "vsphere_virtual_machine" "template_monitor" {
 
 ## Step 2: Create Player View ~10 minutes
 
+In Step 2, you create a Player view with applications and teams to present the lab experience to participants.
+
 ### Create a New View
 
 1. Navigate to **Player**, **Administration**, **Views**.
@@ -198,6 +202,8 @@ data "vsphere_virtual_machine" "template_monitor" {
      - **Status:** Active
 
 ### Add Applications
+
+Add two applications to the view: one for VM access and one for the lab guide.
 
 #### VM List Application
 
@@ -232,6 +238,8 @@ data "vsphere_virtual_machine" "template_monitor" {
 5. Add users to the team using the search function.
 
 ## Step 3: Create Scenario (Steamfitter) ~20 minutes
+
+In Step 3, you define a Steamfitter scenario template with a sequence of manual and timed tasks.
 
 ### Create a Scenario Template
 
@@ -300,6 +308,8 @@ Task 5: Monitoring Alert (Timed)
 
 ## Step 4: Create Alloy Definition ~5 minutes
 
+In Step 4, you create an Alloy event definition that links the Player view, Caster directory, and Steamfitter scenario together.
+
 ### Create an Event Definition
 
 1. Navigate to **Alloy**, **Administration**, **Event Templates**.
@@ -321,6 +331,8 @@ Connect the range components to the event definition:
 
 ## Step 5: Test Deployment ~10 minutes
 
+In Step 5, you launch a test event end-to-end, validate each component, then end the event and confirm cleanup.
+
 ### Launch a Test Event
 
 1. In Alloy, locate your event definition.
@@ -333,6 +345,8 @@ Connect the range components to the event definition:
      - Player exercise clone
 
 ### Validate Components
+
+After launching, confirm that each component deployed successfully.
 
 #### Infrastructure
 
@@ -372,6 +386,8 @@ This quick start results in a basic penetration testing lab that includes:
 - Full exercise lifecycle management.
 
 ## Next Steps
+
+Now that you have a working lab, here are some ways to build on it.
 
 ### Enhance Infrastructure
 

--- a/docs/roles/range-builder/scenarios/index.md
+++ b/docs/roles/range-builder/scenarios/index.md
@@ -15,6 +15,8 @@ Steamfitter enables you to create dynamic, responsive scenarios that adapt to pa
 
 ## Scenario Architecture
 
+The following sections cover task grouping, trigger types, and scoring approaches for building Steamfitter scenarios.
+
 ### Task Grouping
 
 Organize activities into logical **phases**:
@@ -65,6 +67,8 @@ Organize activities into logical **phases**:
 
 ## Common Scenario Patterns
 
+The following sections show example task sequences for common exercise types.
+
 ### Incident Response Scenario
 
 | Phase             | Task                                                | Description                  | Trigger               | Notes                          |
@@ -95,6 +99,8 @@ Organize activities into logical **phases**:
 | **Advanced**     | Exploit Development      | Develop custom exploit   | After assessment | Advanced     | 50     | 1 hour     |
 
 ## Advanced Scenario Techniques
+
+The following sections cover evolving scenarios, branching logic, and other advanced patterns.
 
 ### Evolving Scenarios
 

--- a/docs/tutorials/gameboard-build/index.md
+++ b/docs/tutorials/gameboard-build/index.md
@@ -124,6 +124,8 @@ For additional details on facilitating a game, see:
 
 ## Troubleshooting Common Issues
 
+The following sections cover common problems you may encounter when building a Gameboard game.
+
 ### Challenge Not Appearing in Search
 
 1. Verify that Gameboard can reach the TopoMojo API over the network.

--- a/docs/tutorials/topomojo-challenge/index.md
+++ b/docs/tutorials/topomojo-challenge/index.md
@@ -109,6 +109,8 @@ In TopoMojo, click **Save**. The changes we made to the VM, including the two fi
 
 ## Step 3: Configuring Transforms, Guest Settings, and Questions
 
+In Step 3, you configure transforms and guest settings to randomize the challenge token, then add the question participants must answer to complete the challenge.
+
 ### Adding a Transform
 
 If you recall, the script we wrote reads the value of a guest info variable named `token1`. You configure this variable in the **Transforms** section of the **Challenge** tab.
@@ -215,6 +217,8 @@ The screenshot below shows the terminal in the gamespace after running `get-toke
 At this point, you have a complete, working TopoMojo challenge and the tools to build on it!
 
 ## Beyond the Basics (Optional)
+
+The following optional sections show how to extend the challenge with additional transforms, variants, and more complex scoring.
 
 ### Adding an Additional Transform
 
@@ -330,6 +334,8 @@ For additional details, see [Variants](../../topomojo/index.md#variants) in the 
 6. **Clean Before Saving:** Clean templates before saving them. Remove command and browser history, delete logs, and remove development artifacts or files to prevent unintended hints or shortcuts.
 
 ## Troubleshooting Common Issues
+
+The following sections cover common problems you may encounter when building a TopoMojo challenge.
 
 ### VM Changes Don't Persist
 


### PR DESCRIPTION
Added a custom markdownlint rule that catches consecutive headings with no content between them, then resolved all violations the rule surfaced.

**Custom lint rule:**
- `.github/linting/no-empty-sections.js` flags any heading immediately followed by another heading with no intervening content
- Registered rule in .markdownlint-cli2.yaml via customRules
- Excluded H1 headings and files outside docs/ to avoid false positives

**Empty section fixes:**
- Added brief introductory content to empty ## and ### sections across Crucible Docs

**Removed hotspot headings:**
- Hotspot headings removed and actual descriptive headings bumped up (Blueprint, CITE, Gallery)
- Folded content directly under parent #### headings as plain prose
- Flagged affected screenshots with <!-- TODO:  --> comments for follow-up replacement