### PR TITLE
Standardized "Cog" vs "Gear" settings icon terminology

### DIFF
--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -50,7 +50,7 @@ If the exercise administrator has granted the appropriate permissions, follow th
 
 ![Blueprint Add Team OE](img/blueprintAddUnit.png)
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Units Administration View, click **+**.
 3. Fill the fields as necessary following the Data Format Table specifications.
 
@@ -67,7 +67,7 @@ After you've added all desired configurations, click **Save**.
 
 To edit a unit, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under Units Administration View, select the unit you want to edit and click **Edit** next to it.
 3. The system opens the same edit component used when creating a new unit.
 4. Make your changes, then click **Save**.
@@ -76,14 +76,14 @@ To edit a unit, follow these steps:
 
 To delete a unit, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Units Administration View, select the unit you want to delete and click the **Trash Can** next to it.
 
 ##### Search for a Unit
 
 To search for a specific unit, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Units Administration View, click the **Search Bar** and type the name of the desired unit.
 
 ##### Add/Remove Users from a Unit
@@ -129,14 +129,14 @@ Click the **Save** icon (a user with a **+** sign), then select the permissions 
 
 To delete a user, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Users Administration View, select the user you want to delete and click the **Trash Can** next to the user.
 
 ##### Search for a User
 
 To search for a specific user, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Users Administration View, click the **Search Bar** and type the name of the desired user.
 
 #### Organization Templates
@@ -170,7 +170,7 @@ After you've added all desired configurations, click **Save**.
 
 To edit an organization template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under Organizations Administration View, select the organization you want to edit and click **Edit** next to the organization template.
 3. The system opens the same edit form used when creating a new organization template.
 4. Make your changes, then click **Save**.
@@ -179,14 +179,14 @@ To edit an organization template, follow these steps:
 
 To delete an organization template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Organizations Administration View, select the organization you want to delete and click the **Trash Can** next to the organization template.
 
 ##### Search For an Organization Template
 
 To search for a specific organization template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Organizations Administration View, click the **Search Bar** and type the name of the desired organization template.
 
 #### Gallery Card Templates
@@ -217,7 +217,7 @@ After you've added all desired configurations, click **Save**.
 
 To edit a Gallery card template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under Gallery Cards Administration View, select the card template you want to edit and click **Edit** next to it.
 3. The system opens the same edit component used when creating a new card template.
 4. Make your changes, then click **Save**.
@@ -226,14 +226,14 @@ To edit a Gallery card template, follow these steps:
 
 To delete an Gallery card template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Gallery Cards Administration View, select the card template you want to delete and click the **Trash Can** next to it.
 
 ##### Search for a Gallery Card Template
 
 To search for a specific Gallery card template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the Gallery Cards Administration View, click the **Search Bar** and type the name of the desired card template.
 
 #### CITE Actions Templates
@@ -263,7 +263,7 @@ After you've added all desired configurations, click **Save**.
 
 To edit a CITE action template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under CITE Actions Administration View, select the action template you want to edit and click **Edit** next to it.
 3. The system opens the same edit component used when creating a new action template.
 4. Make your changes, then click **Save**.
@@ -272,14 +272,14 @@ To edit a CITE action template, follow these steps:
 
 To delete a CITE action template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the CITE Actions Administration View, select the action template you want to delete and click the **Trash Can** next to it.
 
 ##### Search for a CITE Action Template
 
 To search for a specific CITE action template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the CITE Actions Administration View, click the **Search Bar** and type the name of the desired action template.
 
 #### CITE Roles Templates
@@ -309,7 +309,7 @@ After you've added all desired configurations, click **Save**.
 
 To edit a CITE role template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under CITE Roles Administration View, select the role template you want to edit and click **Edit** next to it.
 3. The system opens the same edit component used when creating a new role template.
 4. Make your changes, then click **Save**.
@@ -318,14 +318,14 @@ To edit a CITE role template, follow these steps:
 
 To delete a CITE role template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the CITE Roles Administration View, select the role template you want to delete and click the **Trash Can** next to it.
 
 ##### Search For a CITE Role Template
 
 To search for a specific CITE role template, follow these steps:
 
-1. Click the **Settings Cog** in the top-right corner of the screen.
+1. Click the **Gear** icon in the top-right corner.
 2. Under the CITE Roles Administration View, click the **Search Bar** and type the name of the desired role template.
 
 ## User Guide
@@ -423,9 +423,9 @@ Search for a specific MSEL by name.
 
 Users with the appropriate administrative permissions can load and view all MSELs created.
 
-#### Settings Cog
+#### Gear
 
-Users with the appropriate administrative permissions can use the Settings Cog to access Blueprint's administrative settings.
+Users with the appropriate administrative permissions can use the **Gear** icon to access Blueprint's administrative settings.
 
 #### Manage MSEL
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -76,7 +76,7 @@ To save these settings, click **Save**.
 
 To edit an evaluation, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click **Edit** next to the evaluation.
 4. The system opens the same edit component used when creating a new evaluation.
@@ -86,7 +86,7 @@ To edit an evaluation, follow these steps:
 
 To delete an evaluation, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to delete and click the **Trash Can** next to the evaluation.
 
@@ -94,7 +94,7 @@ To delete an evaluation, follow these steps:
 
 To upload an evaluation, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Click the **Up Arrow** next to the **+**.
 4. Select the evaluation JSON file to upload.
@@ -103,7 +103,7 @@ To upload an evaluation, follow these steps:
 
 To download an evaluation, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Click the **Down Arrow** next to the evaluation to download.
 4. Look for the JSON file in your Downloads folder.
@@ -112,7 +112,7 @@ To download an evaluation, follow these steps:
 
 To copy an evaluation, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Click **Copy** next to the evaluation to copy.
 4. Look for the evaluation name with the user's name.
@@ -145,7 +145,7 @@ To save these settings, click **Save**.
 
 To edit a move, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click the **Moves** tab.
 4. Select the move to edit and click **Edit** next to the move.
@@ -156,7 +156,7 @@ To edit a move, follow these steps:
 
 To delete a move, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click the **Moves** tab.
 4. Select the move to delete and click the **Trash Can** next to the move.
@@ -183,7 +183,7 @@ To save these settings, click **Save**.
 
 To edit a team, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click the **Teams** tab.
 4. Select the team to edit and click **Edit** next to the team.
@@ -194,7 +194,7 @@ To edit a team, follow these steps:
 
 To delete a team, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click the **Teams** tab.
 4. Select the team to delete and click the **Trash Can** next to the team.
@@ -263,7 +263,7 @@ Aside from these variables, use **>** to set clipping values for the equation.
 
 To edit a scoring model, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click **Edit** next to the scoring model.
 4. The system opens the same edit component used when creating a new scoring model.
@@ -273,7 +273,7 @@ To edit a scoring model, follow these steps:
 
 To upload a scoring model, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Click the **Up Arrow** next to the **+**.
 4. Select the scoring model JSON file to upload.
@@ -282,7 +282,7 @@ To upload a scoring model, follow these steps:
 
 To download a scoring model, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Click the **Down Arrow** next to the scoring model to download.
 4. Look for the JSON file in your Downloads folder.
@@ -291,7 +291,7 @@ To download a scoring model, follow these steps:
 
 To copy a scoring model, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Click **Copy** next to the scoring model to copy.
 4. Look for the scoring model name with the user's name.
@@ -300,7 +300,7 @@ To copy a scoring model, follow these steps:
 
 To delete a scoring model, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to delete and click the **Trash Can** next to the scoring model.
 
@@ -350,7 +350,7 @@ Last but not least, a Scoring Category has a weight by which to multiply the sco
 
 To edit a scoring category, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
 4. Select the scoring category to edit and click **Edit** next to the scoring category.
@@ -361,7 +361,7 @@ To edit a scoring category, follow these steps:
 
 To delete a scoring category, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
 4. Select the scoring category to delete and click the **Trash Can** next to the scoring category.
@@ -392,7 +392,7 @@ To save these settings, click **Save**.
 
 To edit a scoring option, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
 4. Select the scoring category to edit and click the **Scoring Options** tab.
@@ -404,7 +404,7 @@ To edit a scoring option, follow these steps:
 
 To delete a scoring option, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
 4. Select the scoring category to edit and click the **Scoring Options** tab.
@@ -441,7 +441,7 @@ To save these settings, click **Save**.
 
 To edit an action, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Actions** tab.
 3. Select the action to edit and click **Edit** next to the action.
 4. The system opens the same edit component used when creating a new action.
@@ -451,7 +451,7 @@ To edit an action, follow these steps:
 
 To delete an action, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Action** tab.
 3. Select the action to delete and click the **Trash Can** next to the action.
 
@@ -485,7 +485,7 @@ To save these settings, click **Save**.
 
 To edit a role, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Roles** tab.
 3. Select the role to edit and click **Edit** next to the role.
 4. The system opens the same edit component used when creating a new role.
@@ -495,7 +495,7 @@ To edit a role, follow these steps:
 
 To delete a role, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Roles** tab.
 3. Select the role to delete and click the **Trash Can** next to the role.
 
@@ -536,7 +536,7 @@ To save these settings, click **Save**.
 
 To edit a team type, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Team Types** tab.
 3. Select the team type to edit and click **Edit** next to the team type.
 4. The system opens the same edit component used when creating a new team type.
@@ -546,7 +546,7 @@ To edit a team type, follow these steps:
 
 To delete a team type, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Team Types** tab.
 3. Select the team type to delete and click the **Trash Can** next to the team type.
 
@@ -586,7 +586,7 @@ To save these settings, click **Save** and select the desired permissions to ass
 
 To delete a user, follow these steps:
 
-1. Click the **Settings Cog**.
+1. Click the **Gear** icon.
 2. Navigate to the **Users** tab.
 3. Select the users to delete and click the **Trash Can** next to the user.
 

--- a/docs/gameboard/index.md
+++ b/docs/gameboard/index.md
@@ -692,7 +692,7 @@ After participants submit responses, you can no longer change the feedback templ
 This section assumes you hold a role with the appropriate permissions in Gameboard, already created a game, and have logged in.
 
 1. In the top navigation, select **Admin**.
-2. Select an existing game, then select the **Settings cog**. Under Metadata, see the Player Feedback section. Here you can select an existing feedback template and *add*, *preview*, *edit*, *copy*, and *delete* feedback templates.
+2. Select an existing game, then select the **Gear** icon. Under Metadata, see the Player Feedback section. Here you can select an existing feedback template and *add*, *preview*, *edit*, *copy*, and *delete* feedback templates.
 
 ![feedback template icons](img/feedback-temp-icons.png)
 
@@ -773,7 +773,7 @@ Game participants can view, share, and print certificates of completion as proof
 This topic assumes you hold a role with the appropriate permissions in Gameboard, already created a game, and have logged in.
 
 1. In the top navigation, select **Admin**.
-2. Select an existing game, then Select the **Settings cog**. Under Metadata, see the Completion Certificates section. Here you can select an existing certificate template and *add*, *preview*, *edit*, *copy*, and *delete* completion certificate templates.
+2. Select an existing game, then select the **Gear** icon. Under Metadata, see the Completion Certificates section. Here you can select an existing certificate template and *add*, *preview*, *edit*, *copy*, and *delete* completion certificate templates.
 
 ![certificate template icons](img/cert-temp-icons.png)
 
@@ -1019,7 +1019,7 @@ Follow the steps below to transfer text between your local machine (*out of game
 ##### Local to VM
 
 1. Copy text from your local machine.
-2. In the VM console, open **Tools** (cog icon) and paste into the **Clipboard**.
+2. In the VM console, open **Tools** (**gear** icon) and paste into the **Clipboard**.
 3. In the VM, select a destination and click **Paste**.
 
 ##### VM to Local

--- a/docs/tutorials/gameboard-build/index.md
+++ b/docs/tutorials/gameboard-build/index.md
@@ -35,7 +35,7 @@ This tutorial assumes the following:
 
 ### Configuring Game Metadata
 
-Click the **Settings Cog** in **Game Center** to configure the game. Start by configuring the game metadata. Descriptions of key settings appear below. For additional details on game metadata, see [Game Center Settings](../../gameboard/index.md#metadata) in the *Gameboard Administrator Guide*.
+Click the **Gear** icon in **Game Center** to configure the game. Start by configuring the game metadata. Descriptions of key settings appear below. For additional details on game metadata, see [Game Center Settings](../../gameboard/index.md#metadata) in the *Gameboard Administrator Guide*.
 
 - **Name:** Enter the game name that players see on the homepage and in the game lobby. For the purposes of this tutorial, enter `Tutorial`.
 - **Card Image:** Select a graphic to visually identify the game. Use an image sized `750x1080`. Add text to appear on the card here too. In **Card Text Middle**, enter `tutorial`.

--- a/docs/tutorials/topomojo-challenge/index.md
+++ b/docs/tutorials/topomojo-challenge/index.md
@@ -206,7 +206,7 @@ At this point, the challenge includes a transform, guest info variable, instruct
 
      - Launch the Kali VM.
      - Run `get-token.sh` to retrieve the generated value.
-     - Copy it from the VM using the clipboard in the **Settings cog**.
+     - Copy it from the VM using the clipboard in the **Gear** icon.
      - Paste it into the answer field in TopoMojo.
      - **Submit** the answer. When you submit the correct answer, TopoMojo marks the challenge complete and automatically cleans up the gamespace.
 


### PR DESCRIPTION
Changed all instances of "Cog" to "Gear" across the guides to keep terminology consistent throughout.