### PR TITLE
Combine edit procedure steps in CITE and Blueprint guides

### DIFF
--- a/docs/blueprint/index.md
+++ b/docs/blueprint/index.md
@@ -756,9 +756,8 @@ To edit the event's details, follow these steps:
 
 1. Navigate to the **Events** tab.
 2. Select the event you want to edit and click the **Hamburger** icon next to it.
-3. Click **Edit**.
-4. The system opens the same edit component used when creating a new event.
-5. Make your changes, then click **Save**.
+3. Click **Edit**. The system opens the same edit component used when creating a new event.
+4. Make your changes, then click **Save**.
 
 ##### Delete an Event
 
@@ -815,9 +814,8 @@ After you've added all desired configurations, click **Save**.
 To edit an invitation, follow these steps:
 
 1. Navigate to the **Invitations** tab.
-2. Select the invitation you want to edit and click **Edit**.
-3. The system opens the same edit component used when creating a new invitation.
-4. Make your changes, then click **Save**.
+2. Select the invitation you want to edit and click **Edit**. The system opens the same edit component used when creating a new invitation.
+3. Make your changes, then click **Save**.
 
 ##### Delete an Invitation
 
@@ -902,9 +900,8 @@ After you've added all desired configurations, click **Save**.
 To edit the CITE Action's details, follow these steps:
 
 1. Navigate to the **CITE Actions** tab.
-2. Select the action you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new action.
-4. Make your changes, then click **Save**.
+2. Select the action you want to edit and click **Edit** next to it. The system opens the same edit component used when creating a new action.
+3. Make your changes, then click **Save**.
 
 ##### Delete a CITE Action
 
@@ -957,9 +954,8 @@ After you've added all desired configurations, click **Save**.
 To edit the CITE Role's details, follow these steps:
 
 1. Navigate to the **CITE Roles** tab.
-2. Select the role you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new role.
-4. Make your changes, then click **Save**.
+2. Select the role you want to edit and click **Edit** next to it. The system opens the same edit component used when creating a new role.
+3. Make your changes, then click **Save**.
 
 ##### Delete a CITE Role
 
@@ -1049,9 +1045,8 @@ After you've added all desired configurations, click **Save**.
 To edit a Gallery card, follow these steps:
 
 1. Navigate to the **Gallery Cards** tab.
-2. Select the card you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new card.
-4. Make your changes, then click **Save**.
+2. Select the card you want to edit and click **Edit** next to it. The system opens the same edit component used when creating a new card.
+3. Make your changes, then click **Save**.
 
 ##### Delete a Gallery Card
 
@@ -1116,9 +1111,8 @@ After you've added all desired configurations, click **Save**.
 To edit a Player app, follow these steps:
 
 1. Navigate to the **Player Apps** tab.
-2. Select the app you want to edit and click **Edit** next to it.
-3. The system opens the same edit component used when creating a new app.
-4. Make your changes, then click **Save**.
+2. Select the app you want to edit and click **Edit** next to it. The system opens the same edit component used when creating a new app.
+3. Make your changes, then click **Save**.
 
 ##### Delete a Player App
 

--- a/docs/cite/index.md
+++ b/docs/cite/index.md
@@ -88,9 +88,8 @@ To edit an evaluation, follow these steps:
 
 1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
-3. Select the evaluation to edit and click **Edit** next to the evaluation.
-4. The system opens the same edit component used when creating a new evaluation.
-5. After making all necessary edits, click **Save**.
+3. Select the evaluation to edit and click **Edit** next to it. The system opens the same edit component used when creating a new evaluation.
+4. After making all necessary edits, click **Save**.
 
 ##### Delete an Evaluation
 
@@ -158,9 +157,8 @@ To edit a move, follow these steps:
 1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click the **Moves** tab.
-4. Select the move to edit and click **Edit** next to the move.
-5. The system opens the same edit component used when creating a new move.
-6. After making all necessary edits, click **Save**.
+4. Select the move to edit and click **Edit** next to it. The system opens the same edit component used when creating a new move.
+5. After making all necessary edits, click **Save**.
 
 ##### Delete a Move
 
@@ -196,9 +194,8 @@ To edit a team, follow these steps:
 1. Click the **Gear** icon.
 2. Navigate to the **Evaluations** tab.
 3. Select the evaluation to edit and click the **Teams** tab.
-4. Select the team to edit and click **Edit** next to the team.
-5. The system opens the same edit component used when creating a new team.
-6. After making all necessary edits, click **Save**.
+4. Select the team to edit and click **Edit** next to it. The system opens the same edit component used when creating a new team.
+5. After making all necessary edits, click **Save**.
 
 ##### Delete a Team
 
@@ -275,9 +272,8 @@ To edit a scoring model, follow these steps:
 
 1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
-3. Select the scoring model to edit and click **Edit** next to the scoring model.
-4. The system opens the same edit component used when creating a new scoring model.
-5. After making all necessary edits, click **Save**.
+3. Select the scoring model to edit and click **Edit** next to it. The system opens the same edit component used when creating a new scoring model.
+4. After making all necessary edits, click **Save**.
 
 ##### Upload a Scoring Model
 
@@ -363,9 +359,8 @@ To edit a scoring category, follow these steps:
 1. Click the **Gear** icon.
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
-4. Select the scoring category to edit and click **Edit** next to the scoring category.
-5. The system opens the same edit component used when creating a new scoring category.
-6. After making all necessary edits, click **Save**.
+4. Select the scoring category to edit and click **Edit** next to it. The system opens the same edit component used when creating a new scoring category.
+5. After making all necessary edits, click **Save**.
 
 ##### Delete a Scoring Category
 
@@ -406,9 +401,8 @@ To edit a scoring option, follow these steps:
 2. Navigate to the **Scoring Models** tab.
 3. Select the scoring model to edit and click the **Scoring Categories** tab.
 4. Select the scoring category to edit and click the **Scoring Options** tab.
-5. Select the scoring option to edit and click **Edit** next to the scoring option.
-6. The system opens the same edit component used when creating a new scoring option.
-7. After making all necessary edits, click **Save**.
+5. Select the scoring option to edit and click **Edit** next to it. The system opens the same edit component used when creating a new scoring option.
+6. After making all necessary edits, click **Save**.
 
 ##### Delete a Scoring Option
 
@@ -453,9 +447,8 @@ To edit an action, follow these steps:
 
 1. Click the **Gear** icon.
 2. Navigate to the **Actions** tab.
-3. Select the action to edit and click **Edit** next to the action.
-4. The system opens the same edit component used when creating a new action.
-5. After making all necessary edits, click **Save**.
+3. Select the action to edit and click **Edit** next to it. The system opens the same edit component used when creating a new action.
+4. After making all necessary edits, click **Save**.
 
 ##### Delete an Action
 
@@ -497,9 +490,8 @@ To edit a role, follow these steps:
 
 1. Click the **Gear** icon.
 2. Navigate to the **Roles** tab.
-3. Select the role to edit and click **Edit** next to the role.
-4. The system opens the same edit component used when creating a new role.
-5. After making all necessary edits, click **Save**.
+3. Select the role to edit and click **Edit** next to it. The system opens the same edit component used when creating a new role.
+4. After making all necessary edits, click **Save**.
 
 ##### Delete a Role
 
@@ -548,9 +540,8 @@ To edit a team type, follow these steps:
 
 1. Click the **Gear** icon.
 2. Navigate to the **Team Types** tab.
-3. Select the team type to edit and click **Edit** next to the team type.
-4. The system opens the same edit component used when creating a new team type.
-5. After making all necessary edits, click **Save**.
+3. Select the team type to edit and click **Edit** next to it. The system opens the same edit component used when creating a new team type.
+4. After making all necessary edits, click **Save**.
 
 ##### Delete a Team Type
 


### PR DESCRIPTION
Fold "The system opens..." result sentences into the preceding action step across all Edit topics in CITE and Blueprint.